### PR TITLE
bundle:only bundle firmwares bin/elf, fixes and closes #185

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -259,7 +259,14 @@
 			 <include name="doc/*"/>
 			 <include name="patches/**/*"/>
 			 <include name="objects/**/*"/>
-			 <include name="firmware/**/*"/>
+			 <include name="firmware/*" />
+			 <include name="firmware/STM*/**/*" />
+			 <include name="firmware/samples/*" />
+			 <include name="firmware/build/*.bin" />
+			 <include name="firmware/build/*.elf" />
+			 <include name="firmware/flasher/*" />
+			 <include name="firmware/flasher/flasher_build/*.bin" />
+			 <include name="firmware/flasher/flasher_build/*.elf" />
 			 <include name="chibios/*"/>
 			 <include name="chibios/boards/ST_STM32F4_DISCOVERY/*"/>
 			 <include name="chibios/ext/**/*"/>


### PR DESCRIPTION
so user can copy firmware dir safely