### PR TITLE
Improve lib bz2 dependency installation

### DIFF
--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -31,7 +31,7 @@ case $OS in
     Ubuntu|Debian)
         echo "apt-get install -y libtool libudev-dev automake autoconf ant curl lib32z1 lib32ncurses5 lib32bz2-1.0"
         sudo apt-get install -y libtool libudev-dev automake autoconf \
-             ant curl lib32z1 lib32ncurses5
+        ant curl lib32z1 lib32ncurses5
 
         # On more recent versions of Ubuntu
         # the libbz2 package is multi-arch

--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -31,7 +31,18 @@ case $OS in
     Ubuntu|Debian)
         echo "apt-get install -y libtool libudev-dev automake autoconf ant curl lib32z1 lib32ncurses5 lib32bz2-1.0"
         sudo apt-get install -y libtool libudev-dev automake autoconf \
-        ant curl lib32z1 lib32ncurses5 lib32bz2-1.0
+             ant curl lib32z1 lib32ncurses5
+
+        # On more recent versions of Ubuntu
+        # the libbz2 package is multi-arch
+        install_lib_bz2() {
+            sudo apt-get install -y lib32bz2-1.0
+        }
+        set +e
+        if ! install_lib_bz2; then
+            set -e
+            sudo apt-get install -y libbz2-1.0:i386
+        fi
         ;;
     Archlinux|Arch)
         echo "pacman -Syy"
@@ -58,13 +69,13 @@ mkdir -p "${PLATFORM_ROOT}/lib"
 mkdir -p "${PLATFORM_ROOT}/src"
 
 
-if [ ! -d "${PLATFORM_ROOT}/../chibios" ]; 
+if [ ! -d "${PLATFORM_ROOT}/../chibios" ];
 then
     cd "${PLATFORM_ROOT}/src"
     CH_VERSION=2.6.9
     ARDIR=ChibiOS_${CH_VERSION}
     ARCHIVE=${ARDIR}.zip
-    if [ ! -f ${ARCHIVE} ]; 
+    if [ ! -f ${ARCHIVE} ];
     then
         echo "##### downloading ${ARCHIVE} #####"
         curl -L http://sourceforge.net/projects/chibios/files/ChibiOS_RT%20stable/Version%20${CH_VERSION}/${ARCHIVE} > ${ARCHIVE}


### PR DESCRIPTION
build.sh will die on more recent versions of Ubuntu when we attempt to install lib32bz2-1.0. This package now comes in a multi-arch flavor, so what we want is libbz2-1.0:i386. This patch simply attempts to use the old name first and then the new one if needed.