### PR TITLE
Fix patch opening toFront behavior

### DIFF
--- a/src/main/java/axoloti/menus/FileMenu.java
+++ b/src/main/java/axoloti/menus/FileMenu.java
@@ -251,7 +251,7 @@ public class FileMenu extends JMenu {
         }
     }
 
-    private void jMenuOpenActionPerformed(java.awt.event.ActionEvent evt) {       
+    private void jMenuOpenActionPerformed(java.awt.event.ActionEvent evt) {
         FileUtils.Open((JFrame) SwingUtilities.getWindowAncestor(this));
     }
 

--- a/src/main/java/axoloti/menus/FileMenu.java
+++ b/src/main/java/axoloti/menus/FileMenu.java
@@ -35,11 +35,13 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPopupMenu;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import qcmds.QCmdProcessor;
 
 /**
@@ -249,8 +251,8 @@ public class FileMenu extends JMenu {
         }
     }
 
-    private void jMenuOpenActionPerformed(java.awt.event.ActionEvent evt) {
-        FileUtils.Open(MainFrame.mainframe);
+    private void jMenuOpenActionPerformed(java.awt.event.ActionEvent evt) {       
+        FileUtils.Open((JFrame) SwingUtilities.getWindowAncestor(this));
     }
 
     private void jMenuNewPatchActionPerformed(java.awt.event.ActionEvent evt) {


### PR DESCRIPTION
Currently, opening a patch from the MainFrame's menu properly brings it to the front. Opening a patch from an existing open PatchFrame results in the new patch appearing behind the patch that the open was invoked from. This is happening indirectly as a result of the hardcoded reference to MainFrame in FileMenu which gets reused in PatchFrame. We simply grab a reference to the parent frame and use it when creating the open dialog and we get the correct toFront behavior. The open dialog is also then positioned relative to the invoking frame.