### PR TITLE
GUI: basic undo redo

### DIFF
--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -49,6 +49,8 @@ import axoloti.utils.Preferences;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -118,6 +120,9 @@ public class Patch {
     private AxoObjectInstanceAbstract controllerinstance;
 
     public boolean presetUpdatePending = false;
+
+    private List<String> previousStates = new ArrayList<String>();
+    private int currentState = 0;
 
     static public class PatchVersionException
             extends RuntimeException {
@@ -356,6 +361,7 @@ public class Patch {
             settings = new PatchSettings();
         }
         ClearDirty();
+        saveState();
     }
 
     public ArrayList<ParameterInstance> getParameterInstances() {
@@ -376,19 +382,18 @@ public class Patch {
     }
 
     public void SetDirty() {
+        SetDirty(true);
+    }
+
+    public void SetDirty(boolean saveState) {
         dirty = true;
+
         if (container != null) {
             container.SetDirty();
         }
-    }
-
-    @Deprecated
-    public void SetDirty(boolean f) {
-        // use Set and ClearDirty
-        if (f) {
-            SetDirty();
-        } else {
-            ClearDirty();
+        if (saveState) {
+            currentState += 1;
+            saveState();
         }
     }
 
@@ -436,7 +441,7 @@ public class Patch {
         }
         return null;
     }
-    
+
     public Net GetNet(IoletAbstract io) {
         for (Net net : nets) {
             for (InletInstance d : net.dest) {
@@ -444,7 +449,7 @@ public class Patch {
                     return net;
                 }
             }
-            
+
             for (OutletInstance d : net.source) {
                 if (d == io) {
                     return net;
@@ -566,15 +571,14 @@ public class Patch {
         }
         return null;
     }
-    
+
     public Net disconnect(IoletAbstract io) {
         if (!IsLocked()) {
             Net n = GetNet(io);
             if (n != null) {
-                if(io instanceof OutletInstance) {
+                if (io instanceof OutletInstance) {
                     n.source.remove((OutletInstance) io);
-                }
-                else if(io instanceof InletInstance) {
+                } else if (io instanceof InletInstance) {
                     n.dest.remove((InletInstance) io);
                 }
                 if (n.source.size() + n.dest.size() <= 1) {
@@ -673,6 +677,37 @@ public class Patch {
     }
 
     void PreSerialize() {
+    }
+
+    void saveState() {
+        SortByPosition();
+        PreSerialize();
+        Serializer serializer = new Persister();
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        try {
+            serializer.write(this, b);
+            try {
+                previousStates.set(currentState, b.toString());
+            } catch (IndexOutOfBoundsException e) {
+                previousStates.add(b.toString());
+            }
+        } catch (Exception ex) {
+            Logger.getLogger(AxoObjects.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    void loadState() {
+        Serializer serializer = new Persister();
+        ByteArrayInputStream b = new ByteArrayInputStream(previousStates.get(currentState).getBytes());
+        try {
+            Patch p = serializer.read(Patch.class, b);
+            this.objectinstances = p.objectinstances;
+            this.nets = p.nets;
+            this.PostContructor();
+            repaint();
+        } catch (Exception ex) {
+            Logger.getLogger(AxoObjects.class.getName()).log(Level.SEVERE, null, ex);
+        }
     }
 
     boolean save(File f) {
@@ -2502,6 +2537,30 @@ public class Patch {
         Unlock();
         for (AxoObjectInstanceAbstract o : objectinstances) {
             o.Close();
+        }
+    }
+
+    public boolean canUndo() {
+        return !this.IsLocked() && (currentState > 0);
+    }
+
+    public boolean canRedo() {
+        return !this.IsLocked() && (currentState < previousStates.size() - 1);
+    }
+
+    public void undo() {
+        if (canUndo()) {
+            currentState -= 1;
+            loadState();
+            SetDirty(false);
+        }
+    }
+
+    public void redo() {
+        if (canRedo()) {
+            currentState += 1;
+            loadState();
+            SetDirty(false);
         }
     }
 }

--- a/src/main/java/axoloti/PatchFrame.form
+++ b/src/main/java/axoloti/PatchFrame.form
@@ -65,6 +65,30 @@
             <Property name="text" type="java.lang.String" value="Edit"/>
           </Properties>
           <SubComponents>
+            <MenuItem class="javax.swing.JMenuItem" name="undoItem">
+              <Properties>
+                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
+                  <KeyStroke key="Ctrl+Z"/>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Undo"/>
+              </Properties>
+              <Events>
+                <EventHandler event="ancestorAdded" listener="javax.swing.event.AncestorListener" parameters="javax.swing.event.AncestorEvent" handler="undoItemAncestorAdded"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="undoItemActionPerformed"/>
+              </Events>
+            </MenuItem>
+            <MenuItem class="javax.swing.JMenuItem" name="redoItem">
+              <Properties>
+                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
+                  <KeyStroke key="Shift+Ctrl+Z"/>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Redo"/>
+              </Properties>
+              <Events>
+                <EventHandler event="ancestorAdded" listener="javax.swing.event.AncestorListener" parameters="javax.swing.event.AncestorEvent" handler="redoItemAncestorAdded"/>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="redoItemActionPerformed"/>
+              </Events>
+            </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="jMenuItemDelete">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -32,8 +32,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -85,7 +83,7 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         jScrollPane1.getVerticalScrollBar().setUnitIncrement(Constants.Y_GRID / 2);
         jScrollPane1.getHorizontalScrollBar().setUnitIncrement(Constants.X_GRID / 2);
         jScrollPane1.setWheelScrollingEnabled(false);
-        
+
         JMenuItem menuItem = new JMenuItem(new DefaultEditorKit.CutAction());
         menuItem.setText("Cut");
         menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -301,6 +299,8 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         jMenuSaveClip = new javax.swing.JMenuItem();
         jMenuClose = new javax.swing.JMenuItem();
         jMenuEdit = new javax.swing.JMenu();
+        undoItem = new javax.swing.JMenuItem();
+        redoItem = new javax.swing.JMenuItem();
         jMenuItemDelete = new javax.swing.JMenuItem();
         jMenuItemSelectAll = new javax.swing.JMenuItem();
         jMenuItemAddObj = new javax.swing.JMenuItem();
@@ -451,6 +451,42 @@ jMenuClose.addActionListener(new java.awt.event.ActionListener() {
 
     jMenuEdit.setMnemonic('E');
     jMenuEdit.setText("Edit");
+
+    undoItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_Z, java.awt.event.InputEvent.CTRL_MASK));
+    undoItem.setText("Undo");
+    undoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
+        public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
+            undoItemAncestorAdded(evt);
+        }
+        public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
+        }
+        public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
+        }
+    });
+    undoItem.addActionListener(new java.awt.event.ActionListener() {
+        public void actionPerformed(java.awt.event.ActionEvent evt) {
+            undoItemActionPerformed(evt);
+        }
+    });
+    jMenuEdit.add(undoItem);
+
+    redoItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_Z, java.awt.event.InputEvent.SHIFT_MASK | java.awt.event.InputEvent.CTRL_MASK));
+    redoItem.setText("Redo");
+    redoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
+        public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
+            redoItemAncestorAdded(evt);
+        }
+        public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
+        }
+        public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
+        }
+    });
+    redoItem.addActionListener(new java.awt.event.ActionListener() {
+        public void actionPerformed(java.awt.event.ActionEvent evt) {
+            redoItemActionPerformed(evt);
+        }
+    });
+    jMenuEdit.add(redoItem);
 
     jMenuItemDelete.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_DELETE, 0));
     jMenuItemDelete.setText("Delete");
@@ -980,6 +1016,22 @@ jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
         patch.Layers.repaint();
     }//GEN-LAST:event_zoomOutMenuItemActionPerformed
 
+    private void undoItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_undoItemActionPerformed
+        patch.undo();
+    }//GEN-LAST:event_undoItemActionPerformed
+
+    private void redoItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_redoItemActionPerformed
+        patch.redo();
+    }//GEN-LAST:event_redoItemActionPerformed
+
+    private void undoItemAncestorAdded(javax.swing.event.AncestorEvent evt) {//GEN-FIRST:event_undoItemAncestorAdded
+       undoItem.setEnabled(patch.canUndo());
+    }//GEN-LAST:event_undoItemAncestorAdded
+
+    private void redoItemAncestorAdded(javax.swing.event.AncestorEvent evt) {//GEN-FIRST:event_redoItemAncestorAdded
+       redoItem.setEnabled(patch.canRedo());
+    }//GEN-LAST:event_redoItemAncestorAdded
+
     private boolean GoLive() {
         if (patch.getFileNamePath().endsWith(".axs") || patch.container() != null) {
             Object[] options = {"Yes",
@@ -1052,6 +1104,8 @@ jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
     private javax.swing.JPopupMenu.Separator jSeparator4;
     private javax.swing.JPopupMenu.Separator jSeparator5;
     private javax.swing.JPanel jToolbarPanel;
+    private javax.swing.JMenuItem redoItem;
+    private javax.swing.JMenuItem undoItem;
     private axoloti.menus.WindowMenu windowMenu1;
     private javax.swing.JMenuItem zoomDefaultMenuItem;
     private javax.swing.JMenuItem zoomInMenuItem;

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -760,6 +760,7 @@ public class PatchGUI extends Patch {
                 }
             }
             AdjustSize();
+            SetDirty();
         } catch (javax.xml.stream.XMLStreamException ex) {
             // silence
         } catch (Exception ex) {
@@ -892,6 +893,7 @@ public class PatchGUI extends Patch {
             if (isUpdate) {
                 AdjustSize();
                 Layers.repaint();
+                SetDirty();
             }
         } else {
             Logger.getLogger(PatchGUI.class.getName()).log(Level.INFO, "can't move: locked");
@@ -901,6 +903,8 @@ public class PatchGUI extends Patch {
     @Override
     public void PostContructor() {
         super.PostContructor();
+        objectLayerPanel.removeAll();
+        netLayerPanel.removeAll();
         for (AxoObjectInstanceAbstract o : objectinstances) {
             objectLayerPanel.add(o);
         }
@@ -909,6 +913,7 @@ public class PatchGUI extends Patch {
         }
         Layers.setPreferredSize(new Dimension(5000, 5000));
         AdjustSize();
+        Layers.revalidate();
     }
 
     @Override

--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -370,6 +370,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     o.setLocation(o.x, o.y);
                 }
                 patch.AdjustSize();
+                patch.SetDirty();
             }
         }
     }


### PR DESCRIPTION
@JohannesTaelman 

I was able to find a way to complete my previous undo/redo attempt. The approach is fairly non-invasive and captures net, object and parameter changes in what I think is a pretty reasonable way. Its notion of what constitutes an undoable action mirrors how setDirty() currently works. Pasting or moving a group of objects for example is a single undoable action. I'm currently disallowing undo/redo in live mode, but parameter edits are still captured so you can step back through them when you return to edit mode. This is something that can probably be worked around later, but this gets us most of the way there I think.

The UI is the usual thing: undo and redo items in the edit menu with Ctrl-Z and Shift-Ctrl-Z shortcuts respectively.