### PR TITLE
GUI: theme system and editor

### DIFF
--- a/src/main/java/axoloti/FileUtils.java
+++ b/src/main/java/axoloti/FileUtils.java
@@ -115,6 +115,23 @@ public class FileUtils {
             return "Axoloti Object";
         }
     };
+    
+    public final static FileFilter axtFileFilter = new FileFilter() {
+        @Override
+        public boolean accept(File file) {
+            if (file.getName().endsWith(".axt")) {
+                return true;
+            } else if (file.isDirectory()) {
+                return false;
+            }
+            return false;
+        }
+
+        @Override
+        public String getDescription() {
+            return "Axoloti Patcher Theme";
+        }
+    };
 
     public static JFileChooser GetFileChooser() {
         JFileChooser fc = new JFileChooser(prefs.getCurrentFileDirectory());

--- a/src/main/java/axoloti/MainFrame.java
+++ b/src/main/java/axoloti/MainFrame.java
@@ -26,12 +26,12 @@ import axoloti.dialogs.FileManagerFrame;
 import axoloti.dialogs.KeyboardFrame;
 import axoloti.dialogs.PatchBank;
 import axoloti.dialogs.PreferencesFrame;
+import axoloti.dialogs.ThemeEditor;
 import axoloti.object.AxoObjects;
 import axoloti.usb.Usb;
 import axoloti.utils.AxolotiLibrary;
 import axoloti.utils.FirmwareID;
 import axoloti.utils.Preferences;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.EventQueue;
 import java.awt.Point;
@@ -62,7 +62,9 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Style;
 import javax.swing.text.StyleConstants;
 import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.convert.AnnotationStrategy;
 import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.strategy.Strategy;
 import qcmds.QCmdBringToDFUMode;
 import qcmds.QCmdCompilePatch;
 import qcmds.QCmdPing;
@@ -87,6 +89,7 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
     String TargetFirmwareID;
     KeyboardFrame keyboard;
     FileManagerFrame filemanager;
+    ThemeEditor themeEditor;
     AxolotiRemoteControl remote;
     QCmdProcessor qcmdprocessor;
     Thread qcmdprocessorThread;
@@ -111,8 +114,9 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
         final Style styleSevere = jTextPaneLog.addStyle("severe", null);
         final Style styleFine = jTextPaneLog.addStyle("fine", null);
-        StyleConstants.setForeground(styleSevere, Color.red);
-        StyleConstants.setForeground(styleFine, Color.black);
+        jTextPaneLog.setBackground(Theme.getCurrentTheme().Console_Background);
+        StyleConstants.setForeground(styleSevere, Theme.getCurrentTheme().Error_Text);
+        StyleConstants.setForeground(styleFine, Theme.getCurrentTheme().Normal_Text);
 
         Handler logHandler = new Handler() {
             @Override
@@ -188,6 +192,10 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
         //piano.setAlwaysOnTop(true);
         filemanager.setTitle("File Manager");
         filemanager.setVisible(false);
+        
+        themeEditor = new ThemeEditor();
+        themeEditor.setTitle("Theme Editor");
+        themeEditor.setVisible(false);
 
         remote = new AxolotiRemoteControl();
         remote.setTitle("Remote");
@@ -726,7 +734,9 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
     private boolean runTestCompile(File f) {
         Logger.getLogger(MainFrame.class.getName()).log(Level.INFO, "testing {0}", f.getPath());
-        Serializer serializer = new Persister();
+                    
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             boolean status;
             PatchGUI patch1 = serializer.read(PatchGUI.class, f);
@@ -790,7 +800,9 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
     private boolean runUpgradeFile(File f) {
         Logger.getLogger(MainFrame.class.getName()).log(Level.INFO, "upgrading {0}", f.getPath());
-        Serializer serializer = new Persister();
+                    
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             boolean status;
             PatchGUI patch1 = serializer.read(PatchGUI.class, f);
@@ -1049,9 +1061,9 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
         }
 
         if (warning) {
-            jLabelVoltages.setForeground(Color.red);
+            jLabelVoltages.setForeground(Theme.getCurrentTheme().Error_Text);
         } else {
-            jLabelVoltages.setForeground(Color.black);
+            jLabelVoltages.setForeground(Theme.getCurrentTheme().Normal_Text);
         }
     }
 
@@ -1092,6 +1104,10 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
     public FileManagerFrame getFilemanager() {
         return filemanager;
+    }
+    
+    public ThemeEditor getThemeEditor() {
+        return themeEditor;
     }
 
     public AxolotiRemoteControl getRemote() {

--- a/src/main/java/axoloti/Net.java
+++ b/src/main/java/axoloti/Net.java
@@ -163,7 +163,7 @@ public class Net extends JPanel {
     Color GetColor() {
         Color c = GetDataType().GetColor();
         if (c == null) {
-            c = Color.DARK_GRAY;
+            c = Theme.getCurrentTheme().Cable_Default;
         }
         return c;
     }
@@ -210,7 +210,7 @@ public class Net extends JPanel {
             if (GetDataType() != null) {
                 c = GetDataType().GetColor();
             } else {
-                c = Color.BLACK;
+                c = Theme.getCurrentTheme().Cable_Shadow;
             }
             if (!source.isEmpty()) {
                 p0 = source.get(0).getJackLocInCanvas();
@@ -228,14 +228,14 @@ public class Net extends JPanel {
                 lastSource = j;
             }
             Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Color.BLACK);
+            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
             DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
             g2.setColor(c);
             DrawWire(g2, p0.x, p0.y, p1.x, p1.y);
         }
         for (InletInstance i : dest) {
             Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Color.BLACK);
+            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
             DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
             g2.setColor(c);
             DrawWire(g2, p0.x, p0.y, p1.x, p1.y);

--- a/src/main/java/axoloti/NetDragging.java
+++ b/src/main/java/axoloti/NetDragging.java
@@ -72,7 +72,7 @@ public class NetDragging extends Net {
             if (GetDataType() != null) {
                 c = GetDataType().GetColor();
             } else {
-                c = Color.BLACK;
+                c = Theme.getCurrentTheme().Cable_Shadow;
             }
         }
         int lastSource = 0;
@@ -83,7 +83,7 @@ public class NetDragging extends Net {
                 lastSource = j;
             }
             Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Color.BLACK);
+            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
             if (p0 != null && p1 != null) {
                 DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
                 g2.setColor(c);
@@ -92,7 +92,7 @@ public class NetDragging extends Net {
         }
         for (InletInstance i : dest) {
             Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Color.BLACK);
+            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
             if (p0 != null && p1 != null) {
                 DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
                 g2.setColor(c);

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -62,10 +62,12 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.simpleframework.xml.*;
+import org.simpleframework.xml.convert.AnnotationStrategy;
 import org.simpleframework.xml.core.Complete;
 import org.simpleframework.xml.core.Persist;
 import org.simpleframework.xml.core.Persister;
 import org.simpleframework.xml.core.Validate;
+import org.simpleframework.xml.strategy.Strategy;
 import qcmds.QCmdChangeWorkingDirectory;
 import qcmds.QCmdCompilePatch;
 import qcmds.QCmdCreateDirectory;
@@ -678,7 +680,8 @@ public class Patch {
     boolean save(File f) {
         SortByPosition();
         PreSerialize();
-        Serializer serializer = new Persister();
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             serializer.write(this, f);
             MainFrame.prefs.addRecentFile(f.getAbsolutePath());

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -32,8 +32,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -179,15 +177,6 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         if (USBBulkConnection.GetConnection().isConnected()) {
             ShowConnect();
         }
-
-        //        jScrollPane1.setAutoscrolls(true);
-        /*
-         patch.setPreferredSize(new Dimension(5000, 5000));
-         jScrollPane1.getViewport().setSize(5000, 5000);
-         patch.setSize(new Dimension(5000, 5000));
-         patch.setMinimumSize(new Dimension(5000, 5000));
-         patch.setBackground(Color.red);
-         patch.invalidate();*/
     }
     QCmdProcessor qcmdprocessor;
 

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -25,11 +25,9 @@ import axoloti.object.AxoObjectInstanceAbstract;
 import axoloti.object.AxoObjects;
 import axoloti.outlets.OutletInstance;
 import axoloti.utils.Constants;
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
-import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
@@ -75,7 +73,9 @@ import javax.swing.TransferHandler;
 import javax.swing.plaf.LayerUI;
 import org.simpleframework.xml.Root;
 import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.convert.AnnotationStrategy;
 import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.strategy.Strategy;
 import qcmds.QCmdProcessor;
 
 /**
@@ -152,7 +152,7 @@ public class PatchGUI extends Patch {
 
         Layers.setSize(Constants.PATCH_SIZE, Constants.PATCH_SIZE);
         Layers.setVisible(true);
-        Layers.setBackground(Color.LIGHT_GRAY);
+        Layers.setBackground(Theme.getCurrentTheme().Patch_Unlocked_Background);
         Layers.setOpaque(true);
         Layers.invalidate();
         Layers.repaint();
@@ -605,7 +605,8 @@ public class PatchGUI extends Patch {
         if (v.isEmpty()) {
             return;
         }
-        Serializer serializer = new Persister();
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             PatchGUI p = serializer.read(PatchGUI.class, v);
             HashMap<String, String> dict = new HashMap<String, String>();
@@ -1000,14 +1001,14 @@ public class PatchGUI extends Patch {
     public void Lock() {
         super.Lock();
         patchframe.SetLive(true);
-        Layers.setBackground(Color.DARK_GRAY);
+        Layers.setBackground(Theme.getCurrentTheme().Patch_Locked_Background);
     }
 
     @Override
     public void Unlock() {
         super.Unlock();
         patchframe.SetLive(false);
-        Layers.setBackground(Color.LIGHT_GRAY);
+        Layers.setBackground(Theme.getCurrentTheme().Patch_Unlocked_Background);
     }
 
     @Override
@@ -1090,7 +1091,8 @@ public class PatchGUI extends Patch {
     }
 
     public static void OpenPatch(String name, InputStream stream) {
-        Serializer serializer = new Persister();
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             PatchGUI patch1 = serializer.read(PatchGUI.class, stream);
             PatchFrame pf = new PatchFrame(patch1, QCmdProcessor.getQCmdProcessor());
@@ -1115,7 +1117,8 @@ public class PatchGUI extends Patch {
             }
         }
 
-        Serializer serializer = new Persister();
+        Strategy strategy = new AnnotationStrategy();
+        Serializer serializer = new Persister(strategy);
         try {
             PatchGUI patch1 = serializer.read(PatchGUI.class, f);
             PatchFrame pf = new PatchFrame(patch1, QCmdProcessor.getQCmdProcessor());

--- a/src/main/java/axoloti/Theme.java
+++ b/src/main/java/axoloti/Theme.java
@@ -1,0 +1,295 @@
+package axoloti;
+
+import static axoloti.FileUtils.axtFileFilter;
+import static axoloti.MainFrame.prefs;
+import axoloti.object.AxoObjects;
+import axoloti.utils.ColorConverter;
+import components.LabelComponent;
+import java.awt.Color;
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.UIManager;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.convert.Registry;
+import org.simpleframework.xml.convert.RegistryStrategy;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.strategy.Strategy;
+
+@Root
+public class Theme {
+
+    public Theme() {
+        super();
+    }
+
+    private static final Registry REGISTRY = new Registry();
+    private static final Strategy STRATEGY = new RegistryStrategy(Theme.REGISTRY);
+    private static final Serializer SERIALIZER = new Persister(Theme.STRATEGY);
+
+    static {
+        try {
+            REGISTRY.bind(Color.class, ColorConverter.class);
+            REGISTRY.bind(javax.swing.plaf.ColorUIResource.class, ColorConverter.class);
+        } catch (Exception e) {
+            Logger.getLogger(AxoObjects.class.getName()).log(Level.SEVERE, null, e);
+        }
+    }
+
+    private static Theme currentTheme;
+
+    @Element
+    public String Theme_Name = "Default";
+
+// backgrounds
+    @Element
+    public Color Patch_Unlocked_Background = Color.LIGHT_GRAY;
+    @Element
+    public Color Patch_Locked_Background = Color.DARK_GRAY;
+
+// text    
+    @Element
+    public Color Error_Text = Color.RED;
+    @Element
+    public Color Normal_Text = Color.BLACK;
+    @Element
+    public Color Console_Background = Color.WHITE;
+    @Element
+    // UIManager.getColor("Label.foreground") doesn't give the correct value here
+    // for some reason
+    public Color Label_Text = (new JLabel()).getForeground();    
+
+// nets
+    @Element
+    public Color Cable_Default = Color.DARK_GRAY;
+    @Element
+    public Color Cable_Shadow = Color.BLACK;
+    @Element
+    public Color Cable_Bool32 = Color.YELLOW;
+    @Element
+    public Color Cable_CharPointer32 = Color.PINK;
+    @Element
+    public Color Cable_Zombie = Color.WHITE;
+    @Element
+    public Color Cable_Frac32 = Color.BLUE;
+    @Element
+    public Color Cable_Frac32Buffer = Color.RED;
+    @Element
+    public Color Cable_Int32 = Color.GREEN;
+    @Element
+    public Color Cable_Int32Pointer = Color.MAGENTA;
+    @Element
+    public Color Cable_Int8Array = Color.MAGENTA;
+    @Element
+    public Color Cable_Int8Pointer = Color.MAGENTA;
+
+    // objects
+    @Element
+    public Color Object_Default_Background = UIManager.getColor("Panel.background");
+    @Element
+    public Color Object_TitleBar_Background = Color.getHSBColor(0.f, 0.0f, 0.6f);
+    @Element
+    public Color Object_TitleBar_Foreground = (new JLabel()).getForeground();
+    @Element
+    public Color Object_Border_Unselected = Color.WHITE;
+    @Element
+    public Color Object_Border_Selected = Color.BLACK;
+    @Element
+    public Color Object_Zombie_Background = Color.RED;
+
+    @Element
+    public Color Parameter_Default_Background = UIManager.getColor("Panel.background");
+    @Element
+    public Color Parameter_Default_Foreground = Color.BLACK;
+    @Element
+    public Color Parameter_On_Parent_Highlight = Color.BLUE;
+    @Element
+    public Color Paramete_Preset_Highlight = Color.YELLOW;
+
+    @Element
+    public Color Component_Primary = Color.BLACK;
+    @Element
+    public Color Component_Mid_Dark = Color.getHSBColor(0.f, 0.0f, 0.66f);
+    @Element
+    public Color Component_Mid = Color.GRAY;
+    @Element
+    public Color Component_Mid_Light = Color.getHSBColor(0.f, 0.0f, 0.33f);
+    @Element
+    public Color Component_Secondary = Color.WHITE;
+    @Element
+    public Color Component_Illuminated = Color.ORANGE;
+
+    @Element
+    public Color Keyboard_Light = Color.WHITE;
+    @Element
+    public Color Keyboard_Mid = Color.GRAY;
+    @Element
+    public Color Keyboard_Dark = Color.BLACK;
+
+    @Element
+    public Color Led_Strip_On = new Color(0.f, 1.f, 0.f, 1.0f);
+    @Element
+    public Color Led_Strip_Off = new Color(0.f, 0.f, 0.f, 0.5f);
+
+    @Element
+    public Color VU_Dark_Green = new Color(0.0f, 0.3f, 0.0f);
+    @Element
+    public Color VU_Dark_Yellow = new Color(0.4f, 0.4f, 0.0f);
+    @Element
+    public Color VU_Dark_Red = new Color(0.4f, 0.0f, 0.0f);
+
+    @Element
+    public Color VU_Bright_Green = new Color(0.0f, 0.8f, 0.0f);
+    @Element
+    public Color VU_Bright_Yellow = new Color(0.8f, 0.8f, 0.0f);
+    @Element
+    public Color VU_Bright_Red = new Color(0.8f, 0.0f, 0.0f);
+
+    private File FileChooserSave(JFrame frame) {
+        final JFileChooser fc = new JFileChooser(MainFrame.prefs.getCurrentFileDirectory());
+        fc.setAcceptAllFileFilterUsed(false);
+        fc.addChoosableFileFilter(FileUtils.axtFileFilter);
+
+        String fn = this.Theme_Name;
+
+        File f = new File(fn);
+        fc.setSelectedFile(f);
+
+        String ext = "";
+        int dot = fn.lastIndexOf('.');
+        if (dot > 0 && fn.length() > dot + 3) {
+            ext = fn.substring(dot);
+        }
+        if (ext.equalsIgnoreCase(".axt")) {
+            fc.setFileFilter(FileUtils.axtFileFilter);
+        }
+
+        int returnVal = fc.showSaveDialog(frame);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            String filterext = ".axt";
+            if (fc.getFileFilter() == FileUtils.axtFileFilter) {
+                filterext = ".axt";
+            }
+
+            File fileToBeSaved = fc.getSelectedFile();
+            ext = "";
+            String fname = fileToBeSaved.getAbsolutePath();
+            System.out.println(fname);
+            dot = fname.lastIndexOf('.');
+            if (dot > 0 && fname.length() > dot + 3) {
+                ext = fname.substring(dot);
+            }
+
+            if (ext.equalsIgnoreCase(".axt")) {
+                fileToBeSaved = new File(fc.getSelectedFile().toString());
+            } else if (!ext.equals(filterext)) {
+                Object[] options = {"Yes",
+                    "No"};
+                int n = JOptionPane.showOptionDialog(frame,
+                        "File does not match filter, do you want to change extension to " + filterext + " ?",
+                        "Axoloti asks:",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        options,
+                        options[1]);
+                switch (n) {
+                    case JOptionPane.YES_OPTION:
+                        fileToBeSaved = new File(fname.substring(0, fname.length() - ext.length()) + filterext);
+                        break;
+                    case JOptionPane.NO_OPTION:
+                        return null;
+                }
+            }
+
+            if (fileToBeSaved.exists()) {
+                Object[] options = {"Yes",
+                    "No"};
+                int n = JOptionPane.showOptionDialog(frame,
+                        "File exists, do you want to overwrite ?",
+                        "Axoloti asks:",
+                        JOptionPane.YES_NO_OPTION,
+                        JOptionPane.QUESTION_MESSAGE,
+                        null,
+                        options,
+                        options[1]);
+                switch (n) {
+                    case JOptionPane.YES_OPTION:
+                        break;
+                    case JOptionPane.NO_OPTION:
+                        return null;
+                }
+            }
+            return fileToBeSaved;
+        } else {
+            return null;
+        }
+    }
+
+    public JFileChooser GetFileChooser() {
+        JFileChooser fc = new JFileChooser(prefs.getCurrentFileDirectory());
+        fc.setAcceptAllFileFilterUsed(false);
+        fc.addChoosableFileFilter(axtFileFilter);
+        return fc;
+    }
+
+    public void load(JFrame frame) {
+        JFileChooser fc = GetFileChooser();
+        int returnVal = fc.showOpenDialog(frame);
+        if (returnVal == JFileChooser.APPROVE_OPTION) {
+            prefs.setCurrentFileDirectory(fc.getCurrentDirectory().getPath());
+            prefs.SavePrefs();
+            File f = fc.getSelectedFile();
+            if (axtFileFilter.accept(f)) {
+                try {
+                    FileInputStream inputStream = new FileInputStream(f);
+                    currentTheme = Theme.SERIALIZER.read(Theme.class, inputStream);
+                    MainFrame.prefs.setThemePath(f.getAbsolutePath());
+                } catch (Exception ex) {
+                    Logger.getLogger(MainFrame.class.getName()).log(Level.SEVERE, "Unable to open theme {0}", new Object[]{ex});
+                }
+            }
+        }
+    }
+
+    public void save(JFrame frame) {
+        File fileToBeSaved = FileChooserSave(frame);
+        if (fileToBeSaved != null) {
+            try {
+                Theme.SERIALIZER.write(this, fileToBeSaved);
+                MainFrame.prefs.setThemePath(fileToBeSaved.getAbsolutePath());
+            } catch (Exception e) {
+                Logger.getLogger(AxoObjects.class.getName()).log(Level.SEVERE, null, e);
+            }
+        }
+    }
+
+    public static void loadDefaultTheme() {
+        currentTheme = new Theme();
+        MainFrame.prefs.setThemePath(null);
+    }
+
+    public static Theme getCurrentTheme() {
+        if (currentTheme == null) {
+            String themePath = MainFrame.prefs.getThemePath();
+            if (themePath == null) {
+                loadDefaultTheme();
+            } else {
+                try {
+                    FileInputStream inputStream = new FileInputStream(new File(themePath));
+                    currentTheme = Theme.SERIALIZER.read(Theme.class, inputStream);
+                } catch (Exception ex) {
+                    loadDefaultTheme();
+                }
+            }
+        }
+        return currentTheme;
+    }
+}

--- a/src/main/java/axoloti/attribute/AttributeInstance.java
+++ b/src/main/java/axoloti/attribute/AttributeInstance.java
@@ -18,6 +18,7 @@
 package axoloti.attribute;
 
 import axoloti.SDFileReference;
+import axoloti.Theme;
 import axoloti.atom.AtomInstance;
 import axoloti.attributedefinition.AxoAttribute;
 import axoloti.object.AxoObjectInstance;
@@ -53,6 +54,7 @@ public abstract class AttributeInstance<T extends AxoAttribute> extends JPanel i
 
     public void PostConstructor() {
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
         add(new LabelComponent(GetDefinition().getName()));
         doLayout();
         setSize(getPreferredSize());

--- a/src/main/java/axoloti/datatypes/Bool32.java
+++ b/src/main/java/axoloti/datatypes/Bool32.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -59,7 +60,7 @@ public class Bool32 implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.yellow;
+        return Theme.getCurrentTheme().Cable_Bool32;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/CharPtr32.java
+++ b/src/main/java/axoloti/datatypes/CharPtr32.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -50,7 +51,7 @@ public class CharPtr32 implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.PINK;
+        return Theme.getCurrentTheme().Cable_CharPointer32;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/DTZombie.java
+++ b/src/main/java/axoloti/datatypes/DTZombie.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -52,7 +53,7 @@ public class DTZombie implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.WHITE;
+        return Theme.getCurrentTheme().Cable_Zombie;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Frac32.java
+++ b/src/main/java/axoloti/datatypes/Frac32.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -59,7 +60,7 @@ public class Frac32 implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.BLUE;
+        return Theme.getCurrentTheme().Cable_Frac32;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Frac32buffer.java
+++ b/src/main/java/axoloti/datatypes/Frac32buffer.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -68,7 +69,7 @@ public class Frac32buffer extends DataTypeBuffer {
 
     @Override
     public Color GetColor() {
-        return Color.RED;
+        return Theme.getCurrentTheme().Cable_Frac32Buffer;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Int32.java
+++ b/src/main/java/axoloti/datatypes/Int32.java
@@ -17,6 +17,7 @@
  */
 package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -59,7 +60,7 @@ public class Int32 implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.GREEN;
+        return Theme.getCurrentTheme().Cable_Int32;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Int32Ptr.java
+++ b/src/main/java/axoloti/datatypes/Int32Ptr.java
@@ -16,6 +16,7 @@
  * Axoloti. If not, see <http://www.gnu.org/licenses/>.
  */package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -43,7 +44,7 @@ public class Int32Ptr implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.magenta;
+        return Theme.getCurrentTheme().Cable_Int32Pointer;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Int8Array.java
+++ b/src/main/java/axoloti/datatypes/Int8Array.java
@@ -16,6 +16,7 @@
  * Axoloti. If not, see <http://www.gnu.org/licenses/>.
  */package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -43,7 +44,7 @@ public class Int8Array implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.magenta;
+        return Theme.getCurrentTheme().Cable_Int8Array;
     }
 
     @Override

--- a/src/main/java/axoloti/datatypes/Int8Ptr.java
+++ b/src/main/java/axoloti/datatypes/Int8Ptr.java
@@ -16,6 +16,7 @@
  * Axoloti. If not, see <http://www.gnu.org/licenses/>.
  */package axoloti.datatypes;
 
+import axoloti.Theme;
 import java.awt.Color;
 
 /**
@@ -43,7 +44,7 @@ public class Int8Ptr implements DataType {
 
     @Override
     public Color GetColor() {
-        return Color.magenta;
+        return Theme.getCurrentTheme().Cable_Int8Pointer;
     }
 
     @Override

--- a/src/main/java/axoloti/dialogs/ThemeEditor.java
+++ b/src/main/java/axoloti/dialogs/ThemeEditor.java
@@ -1,0 +1,231 @@
+package axoloti.dialogs;
+
+import axoloti.Theme;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.lang.reflect.Field;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JColorChooser;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+
+public class ThemeEditor extends JFrame {
+
+    private Theme theme;
+    private JPanel p;
+
+    public ThemeEditor() {
+        this.setPreferredSize(new Dimension(1000, 1000));
+        theme = Theme.getCurrentTheme();
+        p = new JPanel();
+        JScrollPane s = new JScrollPane(p,
+                JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        p.setLayout(
+                new GridLayout(theme.getClass().getFields().length + 8, 2)
+        );
+        final JButton load = new JButton("Load");
+        load.addMouseListener(new MouseListener() {
+            public void mouseClicked(MouseEvent e) {
+                theme.load(ThemeEditor.this);
+                theme = Theme.getCurrentTheme();
+                update();
+            }
+
+            public void mousePressed(MouseEvent e) {
+
+            }
+
+            public void mouseEntered(MouseEvent e) {
+
+            }
+
+            public void mouseExited(MouseEvent e) {
+
+            }
+
+            public void mouseReleased(MouseEvent e) {
+
+            }
+        });
+        final JButton save = new JButton("Save");
+        save.addMouseListener(new MouseListener() {
+            public void mouseClicked(MouseEvent e) {
+                theme.save(ThemeEditor.this);
+            }
+
+            public void mousePressed(MouseEvent e) {
+
+            }
+
+            public void mouseEntered(MouseEvent e) {
+
+            }
+
+            public void mouseExited(MouseEvent e) {
+
+            }
+
+            public void mouseReleased(MouseEvent e) {
+
+            }
+        });
+        
+        final JButton revertToDefault = new JButton("Load Default");
+        revertToDefault.addMouseListener(new MouseListener() {
+            public void mouseClicked(MouseEvent e) {
+                Theme.loadDefaultTheme();
+                theme = Theme.getCurrentTheme();
+                update();
+            }
+
+            public void mousePressed(MouseEvent e) {
+
+            }
+
+            public void mouseEntered(MouseEvent e) {
+
+            }
+
+            public void mouseExited(MouseEvent e) {
+
+            }
+
+            public void mouseReleased(MouseEvent e) {
+
+            }
+        });
+
+        p.add(load);
+        p.add(save);
+        p.add(revertToDefault);
+        p.add(new JPanel());
+        p.add(new JLabel("Note: reload patch to see changes."));
+        p.add(new JPanel());
+        p.add(new JPanel());
+        p.add(new JPanel());
+
+
+        for (final Field f : theme.getClass().getFields()) {
+            p.add(new JLabel(f.getName().replace("_", " ")));
+            try {
+                if (f.getName() == "Theme_Name") {
+                    final JTextArea textArea = new JTextArea((String) f.get(theme));
+                    p.add(textArea);
+                    textArea.getDocument().addDocumentListener(
+                            new DocumentListener() {
+                        @Override
+                        public void removeUpdate(DocumentEvent e) {
+                            updateThemeName(e);
+                        }
+
+                        @Override
+                        public void insertUpdate(DocumentEvent e) {
+                            updateThemeName(e);
+                        }
+
+                        @Override
+                        public void changedUpdate(DocumentEvent e) {
+                            updateThemeName(e);
+                        }
+                    });
+                } else {
+                    final JButton t = new JButton();
+                    t.setBorder(BorderFactory.createLineBorder(getBackground(), 2));
+                    System.out.println(f);
+                    final Color currentColor = (Color) f.get(theme);
+                    t.setBackground(currentColor);
+                    t.setContentAreaFilled(false);
+                    t.setOpaque(true);
+                    t.addMouseListener(new MouseListener() {
+                        public void mouseClicked(MouseEvent e) {
+                            try {
+                                Color newColor = pickColor(e.getComponent().getBackground());
+                                System.out.println("newColor: " + newColor);
+                                if (newColor != null) {
+                                    f.set(theme, newColor);
+                                    e.getComponent().setBackground(newColor);
+                                    e.getComponent().repaint();
+                                }
+
+                            } catch (IllegalAccessException ex) {
+                                Logger.getLogger(ThemeEditor.class.getName()).log(Level.SEVERE, "{0}", new Object[]{ex});
+                            }
+                        }
+
+                        public void mousePressed(MouseEvent e) {
+
+                        }
+
+                        public void mouseEntered(MouseEvent e) {
+
+                        }
+
+                        public void mouseExited(MouseEvent e) {
+
+                        }
+
+                        public void mouseReleased(MouseEvent e) {
+
+                        }
+                    });
+                    p.add(t);
+                }
+            } catch (IllegalAccessException ex) {
+                Logger.getLogger(ThemeEditor.class.getName()).log(Level.SEVERE, "{0}", new Object[]{ex});
+            }
+        }
+        this.setContentPane(s);
+        this.pack();
+    }
+
+    private void update() {
+        int i = 9;
+        for (final Field f : theme.getClass().getFields()) {
+            Component target = p.getComponent(i);
+            try {
+                try {
+                    Color color = (Color) f.get(theme);
+                    target.setBackground(color);
+                } catch (ClassCastException e) {
+                    String themeName = (String) f.get(theme);
+                    ((JTextArea) target).setText(themeName);
+                }
+            } catch (IllegalAccessException e) {
+                Logger.getLogger(ThemeEditor.class.getName()).log(Level.SEVERE, "{0}", new Object[]{e});
+            }
+            target.repaint();
+            i += 2;
+        }
+    }
+    
+    private void updateThemeName(DocumentEvent e) {
+        try {
+        theme.Theme_Name = e.getDocument().getText(0, e.getDocument().getLength());
+        }
+        catch(BadLocationException ex) {
+            Logger.getLogger(ThemeEditor.class.getName()).log(Level.SEVERE, "{0}", new Object[]{e});
+        }
+    }
+
+    private Color pickColor(Color initial) {
+        return JColorChooser.showDialog(
+                this,
+                "Choose Color",
+                initial);
+    }
+}

--- a/src/main/java/axoloti/inlets/InletInstance.java
+++ b/src/main/java/axoloti/inlets/InletInstance.java
@@ -17,6 +17,7 @@
  */
 package axoloti.inlets;
 
+import axoloti.Theme;
 import axoloti.atom.AtomInstance;
 import axoloti.datatypes.DataType;
 import axoloti.iolet.IoletAbstract;
@@ -68,6 +69,7 @@ public class InletInstance<T extends Inlet> extends IoletAbstract implements Ato
     public InletInstance() {
         this.inlet = null;
         this.axoObj = null;
+        this.setBackground(Theme.getCurrentTheme().Object_Default_Background);
     }
 
     public InletInstance(T inlet, final AxoObjectInstance axoObj) {
@@ -98,9 +100,11 @@ public class InletInstance<T extends Inlet> extends IoletAbstract implements Ato
 
     public final void PostConstructor() {
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
         setMaximumSize(new Dimension(32767, 14));
         jack = new JackInputComponent(this);
         jack.setForeground(inlet.getDatatype().GetColor());
+        jack.setBackground(Theme.getCurrentTheme().Object_Default_Background);
         add(jack);
         add(new SignalMetaDataIcon(inlet.GetSignalMetaData()));
         if (axoObj.getType().GetInlets().size() > 1) {

--- a/src/main/java/axoloti/menus/WindowMenu.java
+++ b/src/main/java/axoloti/menus/WindowMenu.java
@@ -127,6 +127,11 @@ public class WindowMenu extends JMenu {
             jMenuWindow.add(a);
         }
         {
+            WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe.getThemeEditor(), "Theme");
+            //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+            jMenuWindow.add(a);
+        }
+        {
             WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe.getRemote(), "Remote");
             //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
             jMenuWindow.add(a);

--- a/src/main/java/axoloti/object/AxoObjectFromPatch.java
+++ b/src/main/java/axoloti/object/AxoObjectFromPatch.java
@@ -25,7 +25,9 @@ import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.simpleframework.xml.Serializer;
+import org.simpleframework.xml.convert.AnnotationStrategy;
 import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.strategy.Strategy;
 
 /**
  *
@@ -87,7 +89,8 @@ public class AxoObjectFromPatch extends AxoObject {
     @Override
     public void OpenEditor() {
         if (pg == null) {
-            Serializer serializer = new Persister();
+            Strategy strategy = new AnnotationStrategy();
+            Serializer serializer = new Persister(strategy);
             try {
                 pg = serializer.read(PatchGUI.class, f);
                 pf = new PatchFrame((PatchGUI) pg, MainFrame.mainframe.getQcmdprocessor());

--- a/src/main/java/axoloti/object/AxoObjectInstance.java
+++ b/src/main/java/axoloti/object/AxoObjectInstance.java
@@ -24,6 +24,7 @@ import axoloti.PatchFrame;
 import axoloti.PatchGUI;
 import axoloti.SDFileReference;
 import axoloti.Synonyms;
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.attribute.*;
 import axoloti.attributedefinition.AxoAttribute;
@@ -150,6 +151,7 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
 
         LabelComponent idlbl = new LabelComponent(typeName);
         idlbl.setAlignmentX(LEFT_ALIGNMENT);
+        idlbl.setForeground(Theme.getCurrentTheme().Object_TitleBar_Foreground);
         Titlebar.add(idlbl);
 
         Titlebar.setToolTipText("<html>" + getType().sDescription
@@ -264,26 +266,35 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
         });
         InstanceLabel.addMouseMotionListener(mml);
         add(InstanceLabel);
-
+        
         JPanel p_iolets = new JPanel();
+        p_iolets.setBackground(Theme.getCurrentTheme().Object_Default_Background);
+
         p_iolets.setLayout(new BoxLayout(p_iolets, BoxLayout.LINE_AXIS));
         p_iolets.setAlignmentX(LEFT_ALIGNMENT);
         p_iolets.setAlignmentY(TOP_ALIGNMENT);
         p_inlets = new JPanel();
+        p_inlets.setBackground(Theme.getCurrentTheme().Object_Default_Background);
+
         p_inlets.setLayout(new BoxLayout(p_inlets, BoxLayout.PAGE_AXIS));
         p_inlets.setAlignmentX(LEFT_ALIGNMENT);
         p_inlets.setAlignmentY(TOP_ALIGNMENT);
         p_outlets = new JPanel();
+        p_outlets.setBackground(Theme.getCurrentTheme().Object_Default_Background);
+
         p_outlets.setLayout(new BoxLayout(p_outlets, BoxLayout.PAGE_AXIS));
         p_outlets.setAlignmentX(RIGHT_ALIGNMENT);
         p_outlets.setAlignmentY(TOP_ALIGNMENT);
         p_params = new JPanel();
+        p_params.setBackground(Theme.getCurrentTheme().Object_Default_Background);
         if (getType().getRotatedParams()) {
             p_params.setLayout(new BoxLayout(p_params, BoxLayout.LINE_AXIS));
         } else {
             p_params.setLayout(new BoxLayout(p_params, BoxLayout.PAGE_AXIS));
         }
         p_displays = new JPanel();
+        p_displays.setBackground(Theme.getCurrentTheme().Object_Default_Background);
+
         if (getType().getRotatedParams()) {
             p_displays.setLayout(new BoxLayout(p_displays, BoxLayout.LINE_AXIS));
         } else {
@@ -349,7 +360,6 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
         p_iolets.add(Box.createHorizontalGlue());
         p_iolets.add(p_outlets);
         add(p_iolets);
-//        p_iolets.setBackground(Color.red);
 
         for (AxoAttribute p : getType().attributes) {
             AttributeInstance attrp1 = null;

--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -21,6 +21,7 @@ import axoloti.MainFrame;
 import axoloti.Patch;
 import axoloti.PatchGUI;
 import axoloti.SDFileReference;
+import axoloti.Theme;
 import axoloti.ZoomUI;
 import axoloti.ZoomUtils;
 import axoloti.attribute.AttributeInstance;
@@ -32,7 +33,6 @@ import axoloti.utils.CharEscape;
 import axoloti.utils.Constants;
 import components.LabelComponent;
 import components.TextFieldComponent;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
@@ -220,14 +220,19 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
 //        setFocusable(true);
         Titlebar = new TitleBarPanel(this);
         Titlebar.setLayout(new BoxLayout(Titlebar, BoxLayout.LINE_AXIS));
-        Titlebar.setBackground(Color.getHSBColor(0.f, 0.0f, 0.6f));
+        Titlebar.setBackground(Theme.getCurrentTheme().Object_TitleBar_Background);
         Titlebar.setMinimumSize(TitleBarMinimumSize);
         Titlebar.setMaximumSize(TitleBarMaximumSize);
-        setBorder(BorderFactory.createLineBorder(Color.WHITE));
+        setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Unselected));
         setOpaque(true);
         resolveType();
+        
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
+        
+
         setVisible(true);
-//        revalidate();
+        revalidate();
+        repaint();
 
         popup = new JPopupMenu();
 
@@ -527,9 +532,9 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
     public void SetSelected(boolean Selected) {
         if (this.Selected != Selected) {
             if (Selected) {
-                setBorder(BorderFactory.createLineBorder(Color.BLACK));
+                setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Selected));
             } else {
-                setBorder(BorderFactory.createLineBorder(Color.WHITE));
+                setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Unselected));
             }
             repaint();
         }

--- a/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
@@ -19,13 +19,13 @@ package axoloti.object;
 
 import axoloti.Patch;
 import axoloti.PatchGUI;
+import axoloti.Theme;
 import axoloti.inlets.InletInstance;
 import axoloti.inlets.InletInstanceZombie;
 import axoloti.outlets.OutletInstance;
 import axoloti.outlets.OutletInstanceZombie;
 import components.LabelComponent;
 import components.PopupIcon;
-import java.awt.Color;
 import static java.awt.Component.LEFT_ALIGNMENT;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
@@ -59,6 +59,8 @@ public class AxoObjectInstanceZombie extends AxoObjectInstanceAbstract {
         super.PostConstructor();
         LabelComponent idlbl = new LabelComponent(typeName);
         idlbl.setAlignmentX(LEFT_ALIGNMENT);
+        idlbl.setForeground(Theme.getCurrentTheme().Object_TitleBar_Foreground);
+
 
         final PopupIcon popupIcon = new PopupIcon();
         popupIcon.setPopupIconListener(
@@ -96,7 +98,7 @@ public class AxoObjectInstanceZombie extends AxoObjectInstanceAbstract {
         add(Titlebar);
 
         setOpaque(true);
-        setBackground(Color.red);
+        setBackground(Theme.getCurrentTheme().Object_Zombie_Background);
         setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
         InstanceLabel = new LabelComponent(getInstanceName());
         InstanceLabel.setAlignmentX(LEFT_ALIGNMENT);

--- a/src/main/java/axoloti/outlets/OutletInstance.java
+++ b/src/main/java/axoloti/outlets/OutletInstance.java
@@ -17,6 +17,7 @@
  */
 package axoloti.outlets;
 
+import axoloti.Theme;
 import axoloti.atom.AtomInstance;
 import axoloti.datatypes.DataType;
 import axoloti.iolet.IoletAbstract;
@@ -98,6 +99,7 @@ public class OutletInstance<T extends Outlet> extends IoletAbstract implements C
     public final void PostConstructor() {
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
         setMaximumSize(new Dimension(32767, 14));
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
         add(Box.createHorizontalGlue());
         if (axoObj.getType().GetOutlets().size() > 1) {
             add(new LabelComponent(outlet.name));

--- a/src/main/java/axoloti/parameters/ParameterInstance.java
+++ b/src/main/java/axoloti/parameters/ParameterInstance.java
@@ -18,12 +18,14 @@
 package axoloti.parameters;
 
 import axoloti.Preset;
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.atom.AtomInstance;
 import axoloti.datatypes.Value;
 import axoloti.object.AxoObjectInstance;
 import axoloti.realunits.NativeToReal;
 import axoloti.utils.CharEscape;
+import axoloti.utils.ColorConverter;
 import components.AssignMidiCCComponent;
 import components.AssignPresetMenuItems;
 import components.LabelComponent;
@@ -43,11 +45,12 @@ import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.UIManager;
 import javax.swing.event.MouseInputAdapter;
 import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
 import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
+import org.simpleframework.xml.convert.Convert;
 
 /**
  *
@@ -74,7 +77,11 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
     @Attribute(required = false)
     Integer MidiCC = null;
     AssignMidiCCComponent midiAssign;
-
+    
+    @Element(required = false)
+    @Convert(ColorConverter.class)
+    Color customBackgroundColor;
+    
     public ParameterInstance() {
     }
 
@@ -98,6 +105,9 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
     public void CopyValueFrom(ParameterInstance p) {
         if (p.onParent != null) {
             setOnParent(p.onParent);
+        }
+        if (p.customBackgroundColor != null) {
+            this.setCustomBackgroundColor(p.customBackgroundColor);
         }
         SetMidiCC(p.MidiCC);
     }
@@ -346,10 +356,10 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
 
     void SetPresetState(boolean b) { // OBSOLETE
         if (b) {
-            setBackground(Color.yellow);
-        } //            setBackground(UIManager.getColor ( "Panel.background" ));
+            setBackground(Theme.getCurrentTheme().Paramete_Preset_Highlight);
+        }
         else {
-            setBackground(UIManager.getColor("Panel.background"));
+            setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
         }
     }
 
@@ -401,6 +411,14 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
         } else {
             onParent = null;
         }
+    }
+    
+    public Color getCustomBackgroundColor() {
+        return this.customBackgroundColor;
+    }
+    
+    public void setCustomBackgroundColor(Color c) {
+        this.customBackgroundColor = c;
     }
 
     public abstract ACtrlComponent CreateControl();

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32SMapVSlider.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32SMapVSlider.java
@@ -18,9 +18,8 @@
 package axoloti.parameters;
 
 import axoloti.Preset;
+import axoloti.Theme;
 import components.control.VSliderComponent;
-import java.awt.Color;
-import javax.swing.UIManager;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -78,14 +77,14 @@ public class ParameterInstanceFrac32SMapVSlider extends ParameterInstanceFrac32S
         if (i > 0) {
             Preset p = GetPreset(presetEditActive);
             if (p != null) {
-                setBackground(Color.yellow);
+                setBackground(Theme.getCurrentTheme().Paramete_Preset_Highlight);
                 ctrl.setValue(p.value.getDouble());
             } else {
-                setBackground(UIManager.getColor("Panel.background"));
+                setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
                 ctrl.setValue(value.getDouble());
             }
         } else {
-            setBackground(UIManager.getColor("Panel.background"));
+            setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
             ctrl.setValue(value.getDouble());
         }
         if ((presets != null) && (!presets.isEmpty())) {

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
@@ -18,20 +18,28 @@
 package axoloti.parameters;
 
 import axoloti.Preset;
+import axoloti.Theme;
 import axoloti.datatypes.Value;
+import axoloti.utils.ColorConverter;
 import components.AssignMidiCCComponent;
 import components.AssignMidiCCMenuItems;
 import components.AssignModulatorComponent;
 import components.AssignModulatorMenuItems;
 import components.AssignPresetComponent;
+import components.control.ACtrlComponent;
 import components.control.DialComponent;
 import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import javax.swing.BoxLayout;
+import javax.swing.JColorChooser;
 import javax.swing.JMenu;
+import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import javax.swing.UIManager;
 import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.convert.Convert;
 
 /**
  *
@@ -41,7 +49,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
  
     AssignModulatorComponent modulationAssign;
     AssignPresetComponent presetAssign;
-
+    
     public ParameterInstanceFrac32UMap() {
         super();
     }
@@ -74,6 +82,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public void PostConstructor() {
         super.PostConstructor();
         JPanel btns = new JPanel();
+        btns.setBackground(Theme.getCurrentTheme().Object_Default_Background);
         btns.setLayout(new BoxLayout(btns, BoxLayout.PAGE_AXIS));
 
         //lblCC = new LabelComponent("C");
@@ -89,15 +98,17 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
 //        setComponentPopupMenu(new ParameterInstanceUInt7MapPopupMenu3(this));
         addMouseListener(popupMouseListener);
         updateV();
+        
+        ctrl.setCustomBackgroundColor(getCustomBackgroundColor());
     }
 
     @Override
     public void setOnParent(Boolean b) {
         super.setOnParent(b);
         if ((b != null) && b) {
-            setForeground(Color.blue);
+            setForeground(Theme.getCurrentTheme().Parameter_On_Parent_Highlight);
         } else {
-            setForeground(Color.black);
+            setForeground(Theme.getCurrentTheme().Parameter_Default_Foreground);
         }
     }
 
@@ -168,14 +179,14 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
         if (i > 0) {
             Preset p = GetPreset(presetEditActive);
             if (p != null) {
-                setBackground(Color.yellow);
+                setBackground(Theme.getCurrentTheme().Paramete_Preset_Highlight);
                 ctrl.setValue(p.value.getDouble());
             } else {
-                setBackground(UIManager.getColor("Panel.background"));
+                setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
                 ctrl.setValue(value.getDouble());
             }
         } else {
-            setBackground(UIManager.getColor("Panel.background"));
+            setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
             ctrl.setValue(value.getDouble());
         }
         presetAssign.repaint();
@@ -197,6 +208,36 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
         JMenu m2 = new JMenu("Modulation");
         new AssignModulatorMenuItems((ParameterInstanceFrac32UMap<ParameterFrac32>)this, m2);
         m.add(m2);
+        JMenuItem setColorMenuItem = new JMenuItem("Set Custom Color");
+        setColorMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                Color c = JColorChooser.showDialog(
+                axoObj,
+                "Choose Color",
+                Theme.getCurrentTheme().Parameter_Default_Background);
+                ACtrlComponent ctrl = ParameterInstanceFrac32UMap.this.ctrl;
+                if(ctrl != null) {
+                    ParameterInstanceFrac32UMap.this.customBackgroundColor = c;
+                    ctrl.setCustomBackgroundColor(c);
+                    axoObj.patch.repaint();
+                }
+            }
+        });
+        m.add(setColorMenuItem);
+        JMenuItem clearColorMenuItem = new JMenuItem("Clear Custom Color");
+        clearColorMenuItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                ACtrlComponent ctrl = ParameterInstanceFrac32UMap.this.ctrl;
+                if(ctrl != null) {
+                    ParameterInstanceFrac32UMap.this.customBackgroundColor = null;
+                    ctrl.setCustomBackgroundColor(null);
+                    axoObj.patch.repaint();
+                }
+            }
+        });
+        m.add(clearColorMenuItem);
     }
 
     @Override

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMapVSlider.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMapVSlider.java
@@ -18,9 +18,8 @@
 package axoloti.parameters;
 
 import axoloti.Preset;
+import axoloti.Theme;
 import components.control.VSliderComponent;
-import java.awt.Color;
-import javax.swing.UIManager;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -78,14 +77,14 @@ public class ParameterInstanceFrac32UMapVSlider extends ParameterInstanceFrac32U
         if (i > 0) {
             Preset p = GetPreset(presetEditActive);
             if (p != null) {
-                setBackground(Color.yellow);
+                setBackground(Theme.getCurrentTheme().Paramete_Preset_Highlight);
                 ctrl.setValue(p.value.getDouble());
             } else {
-                setBackground(UIManager.getColor("Panel.background"));
+                setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
                 ctrl.setValue(value.getDouble());
             }
         } else {
-            setBackground(UIManager.getColor("Panel.background"));
+            setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
             ctrl.setValue(value.getDouble());
         }
         if ((presets != null) && (!presets.isEmpty())) {

--- a/src/main/java/axoloti/parameters/ParameterInstanceInt32.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceInt32.java
@@ -18,11 +18,10 @@
 package axoloti.parameters;
 
 import axoloti.Preset;
+import axoloti.Theme;
 import axoloti.datatypes.Value;
 import axoloti.datatypes.ValueInt32;
 import axoloti.object.AxoObjectInstance;
-import java.awt.Color;
-import javax.swing.UIManager;
 import org.simpleframework.xml.Attribute;
 
 /**
@@ -74,9 +73,9 @@ public abstract class ParameterInstanceInt32<T extends Parameter> extends Parame
     public void setOnParent(Boolean b) {
         super.setOnParent(b);
         if ((b != null) && b) {
-            setForeground(Color.blue);
+            setForeground(Theme.getCurrentTheme().Parameter_On_Parent_Highlight);
         } else {
-            setForeground(Color.black);
+            setForeground(Theme.getCurrentTheme().Parameter_Default_Foreground);
         }
     }
 
@@ -86,14 +85,14 @@ public abstract class ParameterInstanceInt32<T extends Parameter> extends Parame
         if (i > 0) {
             Preset p = GetPreset(presetEditActive);
             if (p != null) {
-                setBackground(Color.yellow);
+                setBackground(Theme.getCurrentTheme().Paramete_Preset_Highlight);
                 getControlComponent().setValue(p.value.getDouble());
             } else {
-                setBackground(UIManager.getColor("Panel.background"));
+                setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
                 getControlComponent().setValue(value.getDouble());
             }
         } else {
-            setBackground(UIManager.getColor("Panel.background"));
+            setBackground(Theme.getCurrentTheme().Parameter_Default_Background);
             getControlComponent().setValue(value.getDouble());
         }
     }

--- a/src/main/java/axoloti/utils/ColorConverter.java
+++ b/src/main/java/axoloti/utils/ColorConverter.java
@@ -1,0 +1,30 @@
+package axoloti.utils;
+
+import java.awt.Color;
+import org.simpleframework.xml.convert.Converter;
+import org.simpleframework.xml.stream.InputNode;
+import org.simpleframework.xml.stream.OutputNode;
+
+public class ColorConverter implements Converter<Color> {
+    @Override
+    public Color read(InputNode node) throws Exception {
+        Integer red = Integer.parseInt(node.getAttributes().get("red").getValue());
+        Integer green = Integer.parseInt(node.getAttributes().get("green").getValue());
+        Integer blue = Integer.parseInt(node.getAttributes().get("blue").getValue());
+        Integer alpha = Integer.parseInt(node.getAttributes().get("alpha").getValue());
+        return new Color(red, green, blue, alpha);
+    }
+
+    @Override
+    public void write(OutputNode node, Color color) {
+        Integer red = color.getRed();
+        Integer green = color.getGreen();
+        Integer blue = color.getBlue();
+        Integer alpha = color.getAlpha();
+
+        node.setAttribute("red", red.toString());
+        node.setAttribute("green", green.toString());
+        node.setAttribute("blue", blue.toString());
+        node.setAttribute("alpha", alpha.toString());
+    }
+}

--- a/src/main/java/axoloti/utils/Preferences.java
+++ b/src/main/java/axoloti/utils/Preferences.java
@@ -72,6 +72,8 @@ public class Preferences {
     String ControllerObject;
     @Element(required = false)
     Boolean ControllerEnabled;
+    @Element(required = false)
+    String themePath;
 
     @ElementMap(required = false, entry = "Boards", key = "cpuid", attribute = true, inline = true)
     HashMap<String, String> BoardNames;
@@ -456,5 +458,14 @@ public class Preferences {
             }
         }
         ObjectPath = objPath.toArray(new String[0]);
+    }
+    
+    public String getThemePath() {
+        return themePath;
+    }
+    
+    public void setThemePath(String themePath) {
+        this.themePath = themePath;
+        SavePrefs();
     }
 }

--- a/src/main/java/components/AssignMidiCCComponent.java
+++ b/src/main/java/components/AssignMidiCCComponent.java
@@ -17,10 +17,10 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.parameters.ParameterInstanceFrac32UMap;
 import axoloti.utils.Constants;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -86,17 +86,17 @@ public class AssignMidiCCComponent extends JComponent {
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                     RenderingHints.VALUE_ANTIALIAS_ON);
             g2.setFont(Constants.FONT);
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
             g2.fillRect(1, 1, getWidth(), getHeight());
             if (param.getMidiCC() >= 0) {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
                 g2.fillRect(1, 1, 8, getHeight());
-                g2.setColor(Color.white);
+                g2.setColor(Theme.getCurrentTheme().Component_Secondary);
             } else {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
             }
             g2.drawString("C", 1, getHeight() - 2);
-            g2.setColor(Color.black);
+            g2.setColor(Theme.getCurrentTheme().Component_Primary);
             final int rmargin = 2;
             final int htick = 2;
             int[] xp = new int[]{getWidth() - rmargin - htick * 2, getWidth() - rmargin, getWidth() - rmargin - htick};

--- a/src/main/java/components/AssignModulatorComponent.java
+++ b/src/main/java/components/AssignModulatorComponent.java
@@ -17,10 +17,10 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.parameters.ParameterInstanceFrac32UMap;
 import axoloti.utils.Constants;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -85,17 +85,17 @@ public class AssignModulatorComponent extends JComponent {
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                     RenderingHints.VALUE_ANTIALIAS_ON);
             g2.setFont(Constants.FONT);
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
             g2.fillRect(1, 1, getWidth(), getHeight());
             if (param.getModulators() != null) {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
                 g2.fillRect(1, 1, 8, getHeight());
-                g2.setColor(Color.white);
+                g2.setColor(Theme.getCurrentTheme().Component_Secondary);
             } else {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
             }
             g2.drawString("M", 1, getHeight() - 2);
-            g2.setColor(Color.black);
+            g2.setColor(Theme.getCurrentTheme().Component_Primary);
             final int rmargin = 2;
             final int htick = 2;
             int[] xp = new int[]{getWidth() - rmargin - htick * 2, getWidth() - rmargin, getWidth() - rmargin - htick};

--- a/src/main/java/components/AssignPresetComponent.java
+++ b/src/main/java/components/AssignPresetComponent.java
@@ -17,11 +17,11 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.parameters.ParameterInstanceFrac32UMap;
 import axoloti.utils.Constants;
 import components.control.HSliderComponent;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -88,17 +88,17 @@ public class AssignPresetComponent extends JComponent {
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                     RenderingHints.VALUE_ANTIALIAS_ON);
             g2.setFont(Constants.FONT);
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
             g2.fillRect(1, 1, getWidth(), getHeight());
             if ((param.getPresets() != null) && (!param.getPresets().isEmpty())) {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
                 g2.fillRect(1, 1, 8, getHeight());
-                g2.setColor(Color.white);
+                g2.setColor(Theme.getCurrentTheme().Component_Secondary);
             } else {
-                g2.setColor(Color.black);
+                g2.setColor(Theme.getCurrentTheme().Component_Primary);
             }
             g2.drawString("P", 1, getHeight() - 2);
-            g2.setColor(Color.black);
+            g2.setColor(Theme.getCurrentTheme().Component_Primary);
             final int rmargin = 2;
             final int htick = 2;
             int[] xp = new int[]{getWidth() - rmargin - htick * 2, getWidth() - rmargin, getWidth() - rmargin - htick};

--- a/src/main/java/components/ButtonComponent.java
+++ b/src/main/java/components/ButtonComponent.java
@@ -17,9 +17,9 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.utils.Constants;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -142,14 +142,14 @@ public class ButtonComponent extends JComponent implements MouseInputListener, K
         if (isHighlighted) {
             g2.setPaint(getForeground());
             g2.fillRoundRect(2, 2, getWidth() - 4, getHeight() - 4, radius, radius);
-            g2.setPaint(Color.WHITE);
+            g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
             g2.setFont(Constants.FONT);
             g2.drawString(label, 8, getHeight() - 5);
         } else {
             if (isEnabled()) {
-                g2.setPaint(Color.WHITE);
+                g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
             } else {
-                g2.setPaint(getBackground());
+                g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
             }
             g2.fillRoundRect(2, 2, getWidth() - 4, getHeight() - 4, radius, radius);
             g2.setPaint(getForeground());

--- a/src/main/java/components/DropDownComponent.java
+++ b/src/main/java/components/DropDownComponent.java
@@ -17,10 +17,10 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import axoloti.attribute.AttributeInstanceComboBox;
 import axoloti.utils.Constants;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -82,14 +82,14 @@ public class DropDownComponent extends JComponent implements MouseListener {
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
         if (isEnabled()) {
-            g2.setPaint(Color.WHITE);
+            g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setPaint(getBackground());
+            g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         }
         g2.fillRect(1, 1, getWidth() - 2, getHeight() - 2);
-        g2.setColor(Color.BLACK);
+        g2.setColor(Theme.getCurrentTheme().Component_Primary);
         g2.drawRect(1, 1, getWidth() - 2, getHeight() - 2);
-        g2.setColor(Color.BLACK);
+        g2.setColor(Theme.getCurrentTheme().Component_Primary);
         final int rmargin = 5;
         final int htick = 3;
         int[] xp = new int[]{getWidth() - rmargin - htick * 2, getWidth() - rmargin, getWidth() - rmargin - htick};

--- a/src/main/java/components/JackInputComponent.java
+++ b/src/main/java/components/JackInputComponent.java
@@ -17,9 +17,9 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.inlets.InletInstance;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import static java.awt.Component.CENTER_ALIGNMENT;
 import static java.awt.Component.RIGHT_ALIGNMENT;
 import java.awt.Dimension;
@@ -59,16 +59,16 @@ public class JackInputComponent extends JComponent {
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setStroke(stroke);
-        g2.setPaint(getBackground());
+        g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, sz, sz);
         if (inlet.isConnected()) {
-            g2.setPaint(Color.BLACK);
+            g2.setPaint(Theme.getCurrentTheme().Component_Primary);
             g2.drawOval(margin + 1, margin + 1, sz - margin - margin, sz - margin - margin);
             g2.setPaint(getForeground());
             g2.fillOval(margin, margin, sz - margin - margin, sz - margin - margin);
             g2.drawOval(margin, margin, sz - margin - margin, sz - margin - margin);
         } else {
-            g2.setPaint(Color.BLACK);
+            g2.setPaint(Theme.getCurrentTheme().Component_Primary);
             g2.drawOval(margin + 1, margin + 1, sz - margin - margin, sz - margin - margin);
             g2.setPaint(getForeground());
             g2.drawOval(margin, margin, sz - margin - margin, sz - margin - margin);

--- a/src/main/java/components/JackOutputComponent.java
+++ b/src/main/java/components/JackOutputComponent.java
@@ -17,9 +17,9 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.outlets.OutletInstance;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import static java.awt.Component.CENTER_ALIGNMENT;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -58,10 +58,10 @@ public class JackOutputComponent extends JComponent {
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setPaint(getBackground());
+        g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, sz, sz);
         g2.setStroke(stroke);
-        g2.setPaint(Color.BLACK);
+        g2.setPaint(Theme.getCurrentTheme().Component_Primary);
         g2.drawRect(margin, margin + 1, sz - margin - margin, sz - margin - margin);
 
         if (outlet.isConnected()) {

--- a/src/main/java/components/LabelComponent.java
+++ b/src/main/java/components/LabelComponent.java
@@ -17,6 +17,7 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.utils.Constants;
 import javax.swing.JLabel;
 
@@ -29,5 +30,7 @@ public class LabelComponent extends JLabel {
     public LabelComponent(String text) {
         super(text);
         setFont(Constants.FONT);
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
+        setForeground(Theme.getCurrentTheme().Label_Text);
     }
 }

--- a/src/main/java/components/PianoComponent.java
+++ b/src/main/java/components/PianoComponent.java
@@ -17,8 +17,8 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.utils.Constants;
-import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.event.MouseEvent;
@@ -121,22 +121,22 @@ public abstract class PianoComponent extends JComponent {
             if (y == 0) {
                 if (selection[i]) {
                     // selected
-                    g2.setColor(Color.gray);
+                    g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     g2.fillRect(x, 0, 2 * KeyWidth, height);
                     if (isEnabled()) {
-                        g2.setColor(Color.black);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Dark);
                     } else {
-                        g2.setColor(Color.gray);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     }
                     g2.drawRect(x, 0, 2 * KeyWidth, height);
                 } else {
                     // not selected
-                    g2.setColor(Color.white);
+                    g2.setColor(Theme.getCurrentTheme().Keyboard_Light);
                     g2.fillRect(x, 0, 2 * KeyWidth, height);
                     if (isEnabled()) {
-                        g2.setColor(Color.black);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Dark);
                     } else {
-                        g2.setColor(Color.gray);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     }
                     g2.drawRect(x, 0, 2 * KeyWidth, height);
                 }
@@ -148,19 +148,19 @@ public abstract class PianoComponent extends JComponent {
             int x = keyToX(i);
             if (y == 1) {
                 if (selection[i]) {
-                    g2.setColor(Color.gray);
+                    g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     g2.fillRect(x - 1, 0, KeyWidth + 2, blackKeyHeight);
                     if (isEnabled()) {
-                        g2.setColor(Color.black);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Dark);
                     } else {
-                        g2.setColor(Color.gray);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     }
                     g2.drawRect(x - 1, 0, KeyWidth + 2, blackKeyHeight);
                 } else {
                     if (isEnabled()) {
-                        g2.setColor(Color.black);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Dark);
                     } else {
-                        g2.setColor(Color.gray);
+                        g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
                     }
                     g2.fillRect(x - 1, 0, KeyWidth + 2, blackKeyHeight);
                     g2.drawRect(x - 1, 0, KeyWidth + 2, blackKeyHeight);
@@ -187,7 +187,7 @@ public abstract class PianoComponent extends JComponent {
             }
         }
         int x = keyToX(64);
-        g2.setColor(Color.gray);
+        g2.setColor(Theme.getCurrentTheme().Keyboard_Mid);
         g2.fillOval(x + 2, height - (KeyWidth + 2), KeyWidth, KeyWidth);
     }
 

--- a/src/main/java/components/PopupIcon.java
+++ b/src/main/java/components/PopupIcon.java
@@ -17,7 +17,7 @@
  */
 package components;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -57,7 +57,7 @@ public class PopupIcon extends JComponent implements MouseListener {
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setColor(Color.BLACK);
+        g2.setColor(Theme.getCurrentTheme().Component_Primary);
         final int rmargin = 3;
         final int htick = 3;
         int[] xp = new int[]{getWidth() - rmargin - htick * 2, getWidth() - rmargin, getWidth() - rmargin - htick};

--- a/src/main/java/components/RControlButtonWithLed.java
+++ b/src/main/java/components/RControlButtonWithLed.java
@@ -17,7 +17,7 @@
  */
 package components;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -80,13 +80,13 @@ public class RControlButtonWithLed extends Component {
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setPaint(getBackground());
+        g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, width, height);
         if (illuminated) {
-            g2.setPaint(Color.ORANGE);
+            g2.setPaint(Theme.getCurrentTheme().Component_Illuminated);
             g2.fillRoundRect(0, 0, width, height, arc, arc);
         }
-        g2.setPaint(Color.BLACK);
+        g2.setPaint(Theme.getCurrentTheme().Component_Primary);
         if (pressed) {
             g2.fillRoundRect(inset, inset, width - inset * 2, height - inset * 2, arc, arc);
         } else {

--- a/src/main/java/components/RControlColorLed.java
+++ b/src/main/java/components/RControlColorLed.java
@@ -17,6 +17,7 @@
  */
 package components;
 
+import axoloti.Theme;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -29,7 +30,7 @@ import javax.swing.JComponent;
  */
 public class RControlColorLed extends JComponent {
 
-    Color color = Color.WHITE;
+    Color color = Theme.getCurrentTheme().Component_Secondary;
 
     public void setColor(Color color) {
         if (this.color != color) {
@@ -50,9 +51,9 @@ public class RControlColorLed extends JComponent {
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setPaint(getBackground());
+        g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, width, height);
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.drawOval(hoffset, voffset, diameter, diameter);
         g2.setPaint(color);
         g2.fillOval(hoffset, voffset, diameter, diameter);

--- a/src/main/java/components/RControlEncoder.java
+++ b/src/main/java/components/RControlEncoder.java
@@ -18,8 +18,8 @@
 package components;
 
 import axoloti.MainFrame;
+import axoloti.Theme;
 import java.awt.AWTException;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -126,9 +126,9 @@ public abstract class RControlEncoder extends JComponent {
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
                 RenderingHints.VALUE_ANTIALIAS_ON);
-        g2.setPaint(getBackground());
+        g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, width, height);
-        g2.setPaint(Color.BLACK);
+        g2.setPaint(Theme.getCurrentTheme().Component_Primary);
         g2.drawOval(hoffset, voffset, diameter, diameter);
 
         g2.fillOval(hoffset + diameter / 4, voffset + diameter / 4, diameter / 2, diameter / 2);

--- a/src/main/java/components/SignalMetaDataIcon.java
+++ b/src/main/java/components/SignalMetaDataIcon.java
@@ -17,6 +17,7 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.datatypes.SignalMetaData;
 import static axoloti.datatypes.SignalMetaData.bipolar;
 import java.awt.BasicStroke;
@@ -41,6 +42,7 @@ public class SignalMetaDataIcon extends JComponent {
         setMinimumSize(d);
         setMaximumSize(d);
         setPreferredSize(d);
+        setBackground(Theme.getCurrentTheme().Object_Default_Background);
     }
     private final int x1 = 2;
     private final int x2 = 5;

--- a/src/main/java/components/VGraphComponent.java
+++ b/src/main/java/components/VGraphComponent.java
@@ -17,9 +17,9 @@
  */
 package components;
 
+import axoloti.Theme;
 import axoloti.ZoomUtils;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -74,9 +74,9 @@ public class VGraphComponent extends JComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         g2.setStroke(strokeThick);
-        g2.setColor(Color.white);
+        g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, length + 2, vsize + 2);
-        g2.setPaint(Color.LIGHT_GRAY);
+        g2.setPaint(Theme.getCurrentTheme().Patch_Unlocked_Background);
         g2.drawLine(0, y0, length, y0);
         g2.setPaint(getForeground());
         g2.drawRect(0, 0, length + 2, vsize + 2);

--- a/src/main/java/components/control/ACtrlComponent.java
+++ b/src/main/java/components/control/ACtrlComponent.java
@@ -20,6 +20,7 @@ package components.control;
 import axoloti.PatchGUI;
 import axoloti.ZoomUtils;
 import axoloti.object.AxoObjectInstance;
+import java.awt.Color;
 import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -50,6 +51,7 @@ import javax.swing.TransferHandler;
 public abstract class ACtrlComponent extends JComponent {
 
     protected AxoObjectInstance axoObj;
+    protected Color customBackgroundColor;
 
     public ACtrlComponent() {
         setFocusable(true);
@@ -202,5 +204,9 @@ public abstract class ACtrlComponent extends JComponent {
     
     public void robotMoveToCenter() {
         
+    }
+    
+    public void setCustomBackgroundColor(Color c) {
+        this.customBackgroundColor = c;
     }
 }

--- a/src/main/java/components/control/Checkbox4StatesComponent.java
+++ b/src/main/java/components/control/Checkbox4StatesComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -180,9 +180,9 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         }
         g2.fillRect(0, 0, bsize * n, bsize + 1);
         g2.setPaint(getForeground());
@@ -206,16 +206,16 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
             for (int i = 0; i < n; i++) {
                 switch (v & 3) {
                     case 0:
-                        g2.setColor(Color.white);
+                        g2.setColor(Theme.getCurrentTheme().Component_Secondary);
                         break;
                     case 1:
-                        g2.setColor(Color.getHSBColor(0.0f, 0.0f, 0.66f));
+                        g2.setColor(Theme.getCurrentTheme().Component_Mid_Dark);
                         break;
                     case 2:
-                        g2.setColor(Color.getHSBColor(0.0f, 0.0f, 0.33f));
+                        g2.setColor(Theme.getCurrentTheme().Component_Mid_Light);
                         break;
                     case 3:
-                        g2.setColor(Color.black);
+                        g2.setColor(Theme.getCurrentTheme().Component_Primary);
                         break;
                 }
                 g2.fillRect(i * bsize + inset, inset, bsize - inset - 1, bsize - inset);

--- a/src/main/java/components/control/CheckboxComponent.java
+++ b/src/main/java/components/control/CheckboxComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -172,9 +172,9 @@ public class CheckboxComponent extends ACtrlComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         }
         g2.fillRect(0, 0, bsize * n, bsize + 1);
         g2.setPaint(getForeground());

--- a/src/main/java/components/control/DialComponent.java
+++ b/src/main/java/components/control/DialComponent.java
@@ -18,14 +18,13 @@
 package components.control;
 
 import axoloti.MainFrame;
-import axoloti.PatchGUI;
+import axoloti.Theme;
 import axoloti.datatypes.ValueFrac32;
 import axoloti.realunits.NativeToReal;
 import axoloti.utils.Constants;
 import axoloti.utils.OSDetect;
 import java.awt.AWTException;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -258,9 +257,15 @@ public class DialComponent extends ACtrlComponent {
             g2.setStroke(strokeThin);
         }
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            if(this.customBackgroundColor != null) {
+                g2.setColor(this.customBackgroundColor);
+            }
+            else {
+                g2.setColor(Theme.getCurrentTheme().Component_Secondary);
+
+            }
         } else {
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         }
         g2.fillOval(1, 1, radius * 2 - 2, radius * 2 - 2);
         g2.setPaint(getForeground());
@@ -275,7 +280,7 @@ public class DialComponent extends ACtrlComponent {
                 g2.setFont(Constants.FONT);
                 g2.drawString(s, 0, getSize().height);
             } else {
-                g2.setColor(Color.red);
+                g2.setColor(Theme.getCurrentTheme().Error_Text);
                 g2.setFont(Constants.FONT);
                 g2.drawString(keybBuffer, 0, getSize().height);
             }

--- a/src/main/java/components/control/HRadioComponent.java
+++ b/src/main/java/components/control/HRadioComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -141,9 +141,9 @@ public class HRadioComponent extends ACtrlComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         }
         for (int i = 0; i < n; i++) {
             g2.fillOval(i * bsize, 0, bsize, bsize);

--- a/src/main/java/components/control/HSliderComponent.java
+++ b/src/main/java/components/control/HSliderComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -79,7 +79,7 @@ public class HSliderComponent extends ACtrlComponent {
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         int margin = 50;
         int bwidth = getWidth() - margin;
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.drawRect(0, 0, bwidth, getHeight() - 1);
         g2.setPaint(getForeground());
         g2.drawRect(0, 0, bwidth, getHeight() - 1);

--- a/src/main/java/components/control/NumberBoxComponent.java
+++ b/src/main/java/components/control/NumberBoxComponent.java
@@ -18,13 +18,13 @@
 package components.control;
 
 import axoloti.MainFrame;
+import axoloti.Theme;
 import axoloti.datatypes.ValueFrac32;
 import axoloti.realunits.NativeToReal;
 import axoloti.utils.Constants;
 import axoloti.utils.OSDetect;
 import java.awt.AWTException;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -265,9 +265,9 @@ public class NumberBoxComponent extends ACtrlComponent {
             g2.setStroke(strokeThin);
         }
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setPaint(getBackground());
+            g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
         }
 
         g2.fillRect(0, 0, getWidth(), getHeight());
@@ -294,7 +294,7 @@ public class NumberBoxComponent extends ACtrlComponent {
             g2.setFont(Constants.FONT);
             g2.drawString(s, h, getSize().height - v);
         } else {
-            g2.setColor(Color.red);
+            g2.setColor(Theme.getCurrentTheme().Error_Text);
             g2.setFont(Constants.FONT);
             g2.drawString(keybBuffer, h, getSize().height - v);
         }

--- a/src/main/java/components/control/PulseButtonComponent.java
+++ b/src/main/java/components/control/PulseButtonComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -103,7 +103,7 @@ public class PulseButtonComponent extends ACtrlComponent {
             g2.drawOval(2, 2, bsize - 5, bsize - 5);
             g2.fillOval(2, 2, bsize - 5, bsize - 5);
         } else {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
             g2.fillOval(2, 2, bsize - 5, bsize - 5);
             g2.setPaint(getForeground());
             g2.drawOval(2, 2, bsize - 5, bsize - 5);

--- a/src/main/java/components/control/VRadioComponent.java
+++ b/src/main/java/components/control/VRadioComponent.java
@@ -17,8 +17,8 @@
  */
 package components.control;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -139,9 +139,9 @@ public class VRadioComponent extends ACtrlComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         if (isEnabled()) {
-            g2.setColor(Color.white);
+            g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         } else {
-            g2.setColor(getBackground());
+            g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         }
         for (int i = 0; i < n; i++) {
             g2.fillOval(0, i * bsize, bsize, bsize);

--- a/src/main/java/components/control/VSliderComponent.java
+++ b/src/main/java/components/control/VSliderComponent.java
@@ -18,9 +18,9 @@
 package components.control;
 
 import axoloti.MainFrame;
+import axoloti.Theme;
 import java.awt.AWTException;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -200,7 +200,7 @@ public class VSliderComponent extends ACtrlComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         if (isEnabled()) {
-            g2.setPaint(Color.WHITE);
+            g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
             g2.fillRect(0, 0, getWidth(), height);
             g2.setPaint(getForeground());
             if (isFocusOwner()) {
@@ -225,7 +225,7 @@ public class VSliderComponent extends ACtrlComponent {
             //Rectangle2D r = g2.getFontMetrics().getStringBounds(s, g);
             //g2.drawString(s, bwidth+(margin/2)-(int)(0.5 + r.getWidth()/2), getHeight());
         } else {
-            g2.setPaint(getBackground());
+            g2.setPaint(Theme.getCurrentTheme().Object_Default_Background);
             g2.fillRect(0, 0, getWidth(), height);
             g2.setPaint(getForeground());
             g2.setStroke(strokeThin);

--- a/src/main/java/components/displays/DispComponent.java
+++ b/src/main/java/components/displays/DispComponent.java
@@ -17,9 +17,9 @@
  */
 package components.displays;
 
+import axoloti.Theme;
 import axoloti.utils.Constants;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -59,17 +59,15 @@ public class DispComponent extends ADispComponent {
         int tick = 1;
         int radius = Math.min(getSize().width, getSize().height) / 2 - tick;
         g2.setStroke(strokeThin);
-        g2.setColor(Color.white);
-//        g2.fillRect(0, 0, radius * 2, radius * 2);
+        g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         g2.setPaint(getForeground());
-//        g2.drawRect(0, 0, radius * 2, radius * 2);
         int b = radius / 2;
         g.drawArc(b, b, 2 * (radius - b), 2 * (radius - b), -45, 270);
         double th = 0.75 * Math.PI + (value - min) * (1.5 * Math.PI) / (max - min);
         int x = (int) (Math.cos(th) * radius);
         int y = (int) (Math.sin(th) * radius);
         if (overflow) {
-            g2.setColor(Color.red);
+            g2.setColor(Theme.getCurrentTheme().Error_Text);
         }
         g2.setStroke(strokeThick);
         g2.drawLine(radius, radius, radius + x, radius + y);

--- a/src/main/java/components/displays/LedstripComponent.java
+++ b/src/main/java/components/displays/LedstripComponent.java
@@ -17,6 +17,7 @@
  */
 package components.displays;
 
+import axoloti.Theme;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -44,8 +45,8 @@ public class LedstripComponent extends ADispComponent {
         setSize(d);
     }
 
-    final Color c_off = new Color(0.f, 0.f, 0.f, 0.5f);
-    final Color c_on = new Color(0.f, 1.f, 0.f, 1.0f);
+    final Color c_off = Theme.getCurrentTheme().Led_Strip_Off;
+    final Color c_on = Theme.getCurrentTheme().Led_Strip_On;
 
     @Override
     public void paintComponent(Graphics g) {
@@ -54,7 +55,7 @@ public class LedstripComponent extends ADispComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2.setColor(getBackground());
+        g2.setColor(Theme.getCurrentTheme().Object_Default_Background);
         g2.fillRect(0, 0, bsize * n + 1, bsize + 1);
 //        g2.setPaint(getForeground());
 //        g2.drawRect(0, 0, bsize * n + 1, bsize + 1);

--- a/src/main/java/components/displays/ScopeComponent.java
+++ b/src/main/java/components/displays/ScopeComponent.java
@@ -17,8 +17,8 @@
  */
 package components.displays;
 
+import axoloti.Theme;
 import java.awt.BasicStroke;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -61,7 +61,7 @@ public class ScopeComponent extends ADispComponent {
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
         g2.setStroke(strokeThick);
-        g2.setColor(Color.white);
+        g2.setColor(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, length + 2, vsize + 2);
         g2.setPaint(getForeground());
         g2.drawRect(0, 0, length + 2, vsize + 2);
@@ -69,7 +69,7 @@ public class ScopeComponent extends ADispComponent {
         if (index > 1) {
             g2.drawPolyline(xvalue, value, index - 1);
         }
-        g2.setColor(Color.GRAY);
+        g2.setColor(Theme.getCurrentTheme().Component_Mid);
         if (index < length - 2) {
             g2.drawPolyline(java.util.Arrays.copyOfRange(xvalue, index, length - 1),
                     java.util.Arrays.copyOfRange(value, index, length - 1), length - index - 1);

--- a/src/main/java/components/displays/VBarComponent.java
+++ b/src/main/java/components/displays/VBarComponent.java
@@ -17,7 +17,7 @@
  */
 package components.displays;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -60,13 +60,13 @@ public class VBarComponent extends ADispComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, getWidth(), height);
-        g2.setPaint(Color.BLACK);
+        g2.setPaint(Theme.getCurrentTheme().Component_Primary);
         g2.drawRect(0, 0, getWidth(), height);
         int p = ValToPos(value);
         int p1 = ValToPos(0);
-        g2.setPaint(Color.GRAY);
+        g2.setPaint(Theme.getCurrentTheme().Component_Mid);
         g2.fillRect(margin, p, width - margin * 2, p1 - p);
         //String s = String.format("%5.2f", value);
         //Rectangle2D r = g2.getFontMetrics().getStringBounds(s, g);

--- a/src/main/java/components/displays/VBarComponentDB.java
+++ b/src/main/java/components/displays/VBarComponentDB.java
@@ -17,7 +17,7 @@
  */
 package components.displays;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -70,13 +70,13 @@ public class VBarComponentDB extends ADispComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, getWidth(), height);
-        g2.setPaint(Color.BLACK);
+        g2.setPaint(Theme.getCurrentTheme().Component_Primary);
         g2.drawRect(0, 0, getWidth(), height);
         int p = ValToPos(value);
         int p1 = ValToPos(0);
-        g2.setPaint(Color.GRAY);
+        g2.setPaint(Theme.getCurrentTheme().Component_Mid);
         g2.fillRect(margin, p, width - margin * 2, p1 - p);
     }
 

--- a/src/main/java/components/displays/VLineComponent.java
+++ b/src/main/java/components/displays/VLineComponent.java
@@ -17,7 +17,7 @@
  */
 package components.displays;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -60,11 +60,11 @@ public class VLineComponent extends ADispComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, getWidth(), height);
         int p = ValToPos(value);
         int p1 = ValToPos(0);
-        g2.setPaint(Color.GRAY);
+        g2.setPaint(Theme.getCurrentTheme().Component_Mid);
         g2.drawLine(0, p, 0, p1);
     }
 

--- a/src/main/java/components/displays/VLineComponentDB.java
+++ b/src/main/java/components/displays/VLineComponentDB.java
@@ -17,7 +17,7 @@
  */
 package components.displays;
 
-import java.awt.Color;
+import axoloti.Theme;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -70,11 +70,11 @@ public class VLineComponentDB extends ADispComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        g2.setPaint(Color.WHITE);
+        g2.setPaint(Theme.getCurrentTheme().Component_Secondary);
         g2.fillRect(0, 0, getWidth(), height);
         int p = ValToPos(value);
         int p1 = ValToPos(0);
-        g2.setPaint(Color.GRAY);
+        g2.setPaint(Theme.getCurrentTheme().Component_Mid);
         g2.drawLine(0, p, 0, p1);
     }
 

--- a/src/main/java/components/displays/VUComponent.java
+++ b/src/main/java/components/displays/VUComponent.java
@@ -17,6 +17,7 @@
  */
 package components.displays;
 
+import axoloti.Theme;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -72,13 +73,13 @@ public class VUComponent extends ADispComponent {
         return h - i;
     }
 
-    static Color CDarkGreen = new Color(0.0f, 0.3f, 0.0f);
-    static Color CDarkYellow = new Color(0.4f, 0.4f, 0.0f);
-    static Color CDarkRed = new Color(0.4f, 0.0f, 0.0f);
+    static Color CDarkGreen = Theme.getCurrentTheme().VU_Dark_Green;
+    static Color CDarkYellow = Theme.getCurrentTheme().VU_Dark_Yellow;
+    static Color CDarkRed = Theme.getCurrentTheme().VU_Dark_Red;
 
-    static Color CBrightGreen = new Color(0.0f, 0.8f, 0.0f);
-    static Color CBrightYellow = new Color(0.8f, 0.8f, 0.0f);
-    static Color CBrightRed = new Color(0.8f, 0.0f, 0.0f);
+    static Color CBrightGreen = Theme.getCurrentTheme().VU_Bright_Green;
+    static Color CBrightYellow = Theme.getCurrentTheme().VU_Bright_Yellow;
+    static Color CBrightRed = Theme.getCurrentTheme().VU_Bright_Red;
 
     static int segmentsRed = 2;
     static int segmentsYellow = 3;

--- a/src/main/java/components/displays/VValueLabelsComponent.java
+++ b/src/main/java/components/displays/VValueLabelsComponent.java
@@ -60,13 +60,6 @@ public class VValueLabelsComponent extends JComponent {
                 RenderingHints.VALUE_ANTIALIAS_ON);
         g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
                 RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-//        g2.setColor(getBackground());
-//        g2.fillRect(0, 0, bsize * n + 1, bsize + 1);
-//        g2.setPaint(getForeground());
-//        g2.drawRect(0, 0, bsize * n + 1, bsize + 1);
-//        for (int i = 1; i < n; i++) {
-//            g2.drawLine(bsize * i, 0, bsize * i, bsize + 1);
-//        }
 
         g2.setPaint(getForeground());
         int inset = 3;


### PR DESCRIPTION
Moves color definitions into a Theme type. Adds a ThemeEditor UI that allows the user to pick colors and save and load themes (accessible under the Window menu). A saved theme becomes sticky in user preferences; the current theme saved in preferences is load at startup. Reverting to the default theme is supported in the editor UI as well.

Additionally, a custom color can be set per Dial, and this is persisted along with the patch. If a custom color is set, it overrides the background color coming from the theme.