### PR TITLE
GUI: fix undo for promotion and replace

### DIFF
--- a/src/main/java/axoloti/ObjectSearchFrame.java
+++ b/src/main/java/axoloti/ObjectSearchFrame.java
@@ -468,6 +468,7 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
                     p.AddObjectInstance(x, new Point(patchLocX, patchLocY));
                 } else {
                     p.ChangeObjectInstanceType(target_object, x);
+                    p.cleanUpIntermediateChangeStates(2);
                 }
             }
             setVisible(false);

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -1009,18 +1009,22 @@ jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
 
     private void undoItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_undoItemActionPerformed
         patch.undo();
+        redoItem.setEnabled(patch.canRedo());
+        undoItem.setEnabled(patch.canUndo());
     }//GEN-LAST:event_undoItemActionPerformed
 
     private void redoItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_redoItemActionPerformed
         patch.redo();
+        redoItem.setEnabled(patch.canRedo());        
+        undoItem.setEnabled(patch.canUndo());
     }//GEN-LAST:event_redoItemActionPerformed
 
     private void undoItemAncestorAdded(javax.swing.event.AncestorEvent evt) {//GEN-FIRST:event_undoItemAncestorAdded
-       undoItem.setEnabled(patch.canUndo());
+        undoItem.setEnabled(patch.canUndo());
     }//GEN-LAST:event_undoItemAncestorAdded
 
     private void redoItemAncestorAdded(javax.swing.event.AncestorEvent evt) {//GEN-FIRST:event_redoItemAncestorAdded
-       redoItem.setEnabled(patch.canRedo());
+        redoItem.setEnabled(patch.canRedo());
     }//GEN-LAST:event_redoItemAncestorAdded
 
     private boolean GoLive() {

--- a/src/main/java/axoloti/Theme.java
+++ b/src/main/java/axoloti/Theme.java
@@ -4,7 +4,6 @@ import static axoloti.FileUtils.axtFileFilter;
 import static axoloti.MainFrame.prefs;
 import axoloti.object.AxoObjects;
 import axoloti.utils.ColorConverter;
-import components.LabelComponent;
 import java.awt.Color;
 import java.io.File;
 import java.io.FileInputStream;
@@ -64,7 +63,7 @@ public class Theme {
     @Element
     // UIManager.getColor("Label.foreground") doesn't give the correct value here
     // for some reason
-    public Color Label_Text = (new JLabel()).getForeground();    
+    public Color Label_Text = (new JLabel()).getForeground();
 
 // nets
     @Element
@@ -181,7 +180,6 @@ public class Theme {
             File fileToBeSaved = fc.getSelectedFile();
             ext = "";
             String fname = fileToBeSaved.getAbsolutePath();
-            System.out.println(fname);
             dot = fname.lastIndexOf('.');
             if (dot > 0 && fname.length() > dot + 3) {
                 ext = fname.substring(dot);

--- a/src/main/java/axoloti/dialogs/ThemeEditor.java
+++ b/src/main/java/axoloti/dialogs/ThemeEditor.java
@@ -13,7 +13,6 @@ import java.util.logging.Logger;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JColorChooser;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -84,7 +83,7 @@ public class ThemeEditor extends JFrame {
 
             }
         });
-        
+
         final JButton revertToDefault = new JButton("Load Default");
         revertToDefault.addMouseListener(new MouseListener() {
             public void mouseClicked(MouseEvent e) {
@@ -119,7 +118,6 @@ public class ThemeEditor extends JFrame {
         p.add(new JPanel());
         p.add(new JPanel());
 
-
         for (final Field f : theme.getClass().getFields()) {
             p.add(new JLabel(f.getName().replace("_", " ")));
             try {
@@ -146,7 +144,6 @@ public class ThemeEditor extends JFrame {
                 } else {
                     final JButton t = new JButton();
                     t.setBorder(BorderFactory.createLineBorder(getBackground(), 2));
-                    System.out.println(f);
                     final Color currentColor = (Color) f.get(theme);
                     t.setBackground(currentColor);
                     t.setContentAreaFilled(false);
@@ -155,7 +152,6 @@ public class ThemeEditor extends JFrame {
                         public void mouseClicked(MouseEvent e) {
                             try {
                                 Color newColor = pickColor(e.getComponent().getBackground());
-                                System.out.println("newColor: " + newColor);
                                 if (newColor != null) {
                                     f.set(theme, newColor);
                                     e.getComponent().setBackground(newColor);
@@ -212,12 +208,11 @@ public class ThemeEditor extends JFrame {
             i += 2;
         }
     }
-    
+
     private void updateThemeName(DocumentEvent e) {
         try {
-        theme.Theme_Name = e.getDocument().getText(0, e.getDocument().getLength());
-        }
-        catch(BadLocationException ex) {
+            theme.Theme_Name = e.getDocument().getText(0, e.getDocument().getLength());
+        } catch (BadLocationException ex) {
             Logger.getLogger(ThemeEditor.class.getName()).log(Level.SEVERE, "{0}", new Object[]{e});
         }
     }

--- a/src/main/java/axoloti/object/AxoObjectInstance.java
+++ b/src/main/java/axoloti/object/AxoObjectInstance.java
@@ -489,6 +489,7 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
 
     public void updateObj() {
         getPatch().ChangeObjectInstanceType(this, this.getType());
+        getPatch().cleanUpIntermediateChangeStates(3);
     }
 
     @Override
@@ -874,6 +875,7 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
         if (selected != getType()) {
             Logger.getLogger(AxoObjectInstance.class.getName()).log(Level.INFO, "promoting " + this + " to " + selected);
             patch.ChangeObjectInstanceType(this, selected);
+            patch.cleanUpIntermediateChangeStates(4);
         } else {
             Logger.getLogger(AxoObjectInstance.class.getName()).log(Level.INFO, "no promotion for {0}", typeName);
         }


### PR DESCRIPTION
Both object replace and edit were resulting in multiple undo steps as well. This patch makes sure that they're squashed down as well as in the original promotion case: 
1. undoing a promotion connection removes the connection and returns the object to its unpromoted state
2. undoing a replace does the expected thing
3. object editing is kept out of the patch edit history, previously this would cause useless undo states to accumulate. I think what we probably want eventually is undo and redo for the object editor itself.

This also fixes an issue with the keyboard shortcuts that was caused by the menu enabled state not being updated.
