### PR TITLE
GUI: cleanup comment and hyperlink event handling

### DIFF
--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -80,7 +80,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
     AxoObjectAbstract type;
     boolean dragging = false;
     int dX, dY;
-    private boolean Selected = false;
+    protected boolean Selected = false;
     private boolean Locked = false;
     private boolean typeWasAmbiguous = false;
     JPanel Titlebar;

--- a/src/main/java/axoloti/object/AxoObjectInstanceComment.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceComment.java
@@ -18,9 +18,9 @@
 package axoloti.object;
 
 import axoloti.Patch;
+import axoloti.PatchGUI;
 import components.LabelComponent;
 import components.TextFieldComponent;
-import static java.awt.Component.LEFT_ALIGNMENT;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -30,6 +30,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import org.simpleframework.xml.Attribute;
@@ -74,47 +75,37 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
         }
         setOpaque(true);
         setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
-        add(Box.createHorizontalStrut(5));
         InstanceLabel = new LabelComponent(commentText);
-        InstanceLabel.setAlignmentX(LEFT_ALIGNMENT);
+        InstanceLabel.setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 5));
+        InstanceLabel.setAlignmentX(CENTER_ALIGNMENT);
         InstanceLabel.addMouseListener(new MouseListener() {
             @Override
             public void mouseClicked(MouseEvent me) {
                 if (me.getClickCount() == 2) {
                     addInstanceNameEditor();
                 }
+                if (patch != null) {
+                    if (me.getClickCount() == 1) {
+                        if (me.isShiftDown()) {
+                            SetSelected(!GetSelected());
+                            ((PatchGUI) patch).repaint();
+                        } else if (Selected == false) {
+                            ((PatchGUI) patch).SelectNone();
+                            SetSelected(true);
+                            ((PatchGUI) patch).repaint();
+                        }
+                    }
+                }
             }
 
             @Override
             public void mousePressed(MouseEvent me) {
-                if (me.isPopupTrigger()) {
-                } else if (!IsLocked()) {
-                    dX = me.getXOnScreen() - getX();
-                    dY = me.getYOnScreen() - getY();
-                    dragging = true;
-                    if (IsSelected()) {
-                        for (AxoObjectInstanceAbstract o : patch.objectinstances) {
-                            if (o.IsSelected()) {
-                                o.dX = me.getXOnScreen() - o.getX();
-                                o.dY = me.getYOnScreen() - o.getY();
-                                o.dragging = true;
-                            }
-                        }
-                    }
-                }
+                ml.mousePressed(me);
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
-                if (dragging) {
-                    dragging = false;
-                    if (patch != null) {
-                        for (AxoObjectInstanceAbstract o : patch.objectinstances) {
-                            o.dragging = false;
-                        }
-                        patch.AdjustSize();
-                    }
-                }
+                ml.mouseReleased(e);
             }
 
             @Override

--- a/src/main/java/axoloti/object/AxoObjectInstanceHyperlink.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceHyperlink.java
@@ -107,14 +107,28 @@ public class AxoObjectInstanceHyperlink extends AxoObjectInstanceAbstract {
                 if (e.getClickCount() == 2) {
                     addInstanceNameEditor();
                 }
+                if (patch != null) {
+                    if (e.getClickCount() == 1) {
+                        if (e.isShiftDown()) {
+                            SetSelected(!GetSelected());
+                            ((PatchGUI) patch).repaint();
+                        } else if (Selected == false) {
+                            ((PatchGUI) patch).SelectNone();
+                            SetSelected(true);
+                            ((PatchGUI) patch).repaint();
+                        }
+                    }
+                }
             }
 
             @Override
             public void mousePressed(MouseEvent e) {
+                ml.mousePressed(e);
             }
 
             @Override
             public void mouseReleased(MouseEvent e) {
+                ml.mouseReleased(e);
             }
 
             @Override
@@ -125,6 +139,7 @@ public class AxoObjectInstanceHyperlink extends AxoObjectInstanceAbstract {
             public void mouseExited(MouseEvent e) {
             }
         });
+        InstanceLabel.addMouseMotionListener(mml);
         add(InstanceLabel);
 
         resizeToGrid();


### PR DESCRIPTION
Dragging comments was buggy due to some unnecessarily duplicated event handling code that wasn't handling zooming properly. Also, selection and manipulation for both comments and hyperlinks was a bit unresponsive. The strut on the left part of the comment created an event dead zone. This patch makes these interactions a bit more forgiving.