### PR TITLE
GUI: persist bounds and active tab of object editor

### DIFF
--- a/src/main/java/axoloti/object/AxoObject.java
+++ b/src/main/java/axoloti/object/AxoObject.java
@@ -108,6 +108,7 @@ import axoloti.parameters.ParameterInt32BoxSmall;
 import axoloti.parameters.ParameterInt32HRadio;
 import axoloti.parameters.ParameterInt32VRadio;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -293,16 +294,43 @@ public class AxoObject extends AxoObjectAbstract {
 
     ArrayList<ObjectModifiedListener> instances = new ArrayList<ObjectModifiedListener>();
     AxoObjectEditor editor;
-
-    public void OpenEditor() {
+    
+    Rectangle editorBounds;
+    Integer editorActiveTabIndex;
+    
+    private void setEditorBounds(Rectangle editorBounds) {
+        if(editorBounds != null) {
+            editor.setBounds(editorBounds);
+        }
+        else if(this.editorBounds != null) {
+            editor.setBounds(this.editorBounds);
+        }
+        
+    }
+    
+    private void setEditorActiveTabIndex(Integer editorActiveTabIndex) {
+        if(editorActiveTabIndex != null) {
+            editor.setActiveTabIndex(editorActiveTabIndex);
+        }
+        else if(this.editorActiveTabIndex != null) {
+            editor.setActiveTabIndex(this.editorActiveTabIndex);
+        }
+    }
+    
+    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex) {
         if (editor == null) {
             editor = new AxoObjectEditor(this);
         }
+        
+        setEditorBounds(editorBounds);
+        setEditorActiveTabIndex(editorActiveTabIndex);
+        
         editor.setState(java.awt.Frame.NORMAL);
         editor.setVisible(true);
     }
 
     public void CloseEditor() {
+        FireObjectModified(this);
         editor = null;
     }
 

--- a/src/main/java/axoloti/object/AxoObjectFromPatch.java
+++ b/src/main/java/axoloti/object/AxoObjectFromPatch.java
@@ -21,6 +21,7 @@ import axoloti.MainFrame;
 import axoloti.Patch;
 import axoloti.PatchFrame;
 import axoloti.PatchGUI;
+import java.awt.Rectangle;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -87,7 +88,7 @@ public class AxoObjectFromPatch extends AxoObject {
     }
 
     @Override
-    public void OpenEditor() {
+    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex) {
         if (pg == null) {
             Strategy strategy = new AnnotationStrategy();
             Serializer serializer = new Persister(strategy);

--- a/src/main/java/axoloti/object/AxoObjectInstance.java
+++ b/src/main/java/axoloti/object/AxoObjectInstance.java
@@ -41,6 +41,7 @@ import components.LabelComponent;
 import components.PopupIcon;
 import static java.awt.Component.LEFT_ALIGNMENT;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -424,7 +425,7 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
     }
 
     public void OpenEditor() {
-        getType().OpenEditor();
+        getType().OpenEditor(editorBounds, editorActiveTabIndex);
     }
     
     @Override
@@ -885,6 +886,10 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
     public ArrayList<DisplayInstance> GetDisplayInstances() {
         return displayInstances;
     }
+    
+
+    Rectangle editorBounds;
+    Integer editorActiveTabIndex;
 
     @Override
     public void ObjectModified(Object src) {
@@ -894,6 +899,18 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract implements Obje
             } else {
                 deferredObjTypeUpdate = true;
             }
+        }
+        
+        try {
+            AxoObject o = (AxoObject) src;
+            if(o.editor != null && o.editor.getBounds() != null) {
+                editorBounds = o.editor.getBounds();
+                editorActiveTabIndex = o.editor.getActiveTabIndex();
+                this.getType().editorBounds = editorBounds;
+                this.getType().editorActiveTabIndex = editorActiveTabIndex;
+            }
+        }
+        catch(ClassCastException ex) {
         }
     }
 

--- a/src/main/java/axoloti/objecteditor/AxoObjectEditor.java
+++ b/src/main/java/axoloti/objecteditor/AxoObjectEditor.java
@@ -26,6 +26,7 @@ import axoloti.object.ObjectModifiedListener;
 import axoloti.utils.AxolotiLibrary;
 import java.awt.BorderLayout;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.util.ArrayList;
@@ -404,6 +405,14 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, Obj
         editObj.removeObjectModifiedListener(this);
         dispose();
         editObj.CloseEditor();
+    }
+    
+    public int getActiveTabIndex() {
+        return this.jTabbedPane1.getSelectedIndex();
+    }
+    
+    public void setActiveTabIndex(int n) {
+        this.jTabbedPane1.setSelectedIndex(n);
     }
 
     /**
@@ -804,8 +813,12 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, Obj
     }//GEN-LAST:event_jMenuItemCopyToLibraryActionPerformed
 
     private void jMenuItemRevertActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jMenuItemRevertActionPerformed
+        Rectangle editorBounds = this.getBounds();
+        int activeTabIndex = this.getActiveTabIndex();
         Revert();
         AxoObjectEditor axoObjectEditor = new AxoObjectEditor(editObj);
+        axoObjectEditor.setBounds(editorBounds);
+        axoObjectEditor.setActiveTabIndex(activeTabIndex);
         axoObjectEditor.setVisible(true);
     }//GEN-LAST:event_jMenuItemRevertActionPerformed
 


### PR DESCRIPTION
This pull request causes the object editor to persist its bounds and active tab. This came up as an annoyance on the forums.

There is a bit of trickiness involved for the patcher object case because these data have to be stored on the instance rather than the object type due to the fact that the patcher recreates an AxoObject (the type) whenever updateObj occurs. There is a small change that makes "Revert" behave similarly.