### PR TITLE
GUI: patch rendering performance improvements

### DIFF
--- a/src/main/java/axoloti/MainFrame.java
+++ b/src/main/java/axoloti/MainFrame.java
@@ -629,8 +629,6 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
     private void jButtonClearActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonClearActionPerformed
         jTextPaneLog.setText("");
-        doLayout();
-        repaint();
     }//GEN-LAST:event_jButtonClearActionPerformed
 
     private void jMenuItemPanicActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jMenuItemPanicActionPerformed

--- a/src/main/java/axoloti/NetDragging.java
+++ b/src/main/java/axoloti/NetDragging.java
@@ -22,8 +22,10 @@ import axoloti.outlets.OutletInstance;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.RenderingHints;
+import javax.swing.SwingUtilities;
 
 /**
  *
@@ -75,38 +77,68 @@ public class NetDragging extends Net {
                 c = Theme.getCurrentTheme().Cable_Shadow;
             }
         }
-        int lastSource = 0;
-        for (OutletInstance i : source) {
-//  Indicate latched connections
-            int j = patch.objectinstances.indexOf(i.GetObjectInstance());
-            if (j > lastSource) {
-                lastSource = j;
-            }
-            Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
-            if (p0 != null && p1 != null) {
-                DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
+        if (p0 != null) {
+            Point from = SwingUtilities.convertPoint(getPatchGui().Layers, p0, this);
+            for (InletInstance i : dest) {
+                Point p1 = i.getJackLocInCanvas();
+
+                Point to = SwingUtilities.convertPoint(getPatchGui().Layers, p1, this);
+                g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
+                DrawWire(g2, from.x + shadowOffset, from.y + shadowOffset, to.x + shadowOffset, to.y + shadowOffset);
                 g2.setColor(c);
-                DrawWire(g2, p0.x, p0.y, p1.x, p1.y);
+                DrawWire(g2, from.x, from.y, to.x, to.y);
+            }
+            for (OutletInstance i : source) {
+                Point p1 = i.getJackLocInCanvas();
+
+                Point to = SwingUtilities.convertPoint(getPatchGui().Layers, p1, this);
+                g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
+                DrawWire(g2, from.x + shadowOffset, from.y + shadowOffset, to.x + shadowOffset, to.y + shadowOffset);
+                g2.setColor(c);
+                DrawWire(g2, from.x, from.y, to.x, to.y);
+
             }
         }
-        for (InletInstance i : dest) {
-            Point p1 = i.getJackLocInCanvas();
-            g2.setColor(Theme.getCurrentTheme().Cable_Shadow);
-            if (p0 != null && p1 != null) {
-                DrawWire(g2, p0.x + shadowOffset, p0.y + shadowOffset, p1.x + shadowOffset, p1.y + shadowOffset);
-                g2.setColor(c);
-                DrawWire(g2, p0.x, p0.y, p1.x, p1.y);
+        updateBounds();
+    }
+
+    @Override
+    protected void updateBounds() {
+        try {
+
+            int min_y = Integer.MAX_VALUE;
+            int min_x = Integer.MAX_VALUE;
+            int max_y = Integer.MIN_VALUE;
+            int max_x = Integer.MIN_VALUE;
+
+            if (p0 != null) {
+                min_x = p0.x;
+                max_x = p0.x;
+                min_y = p0.y;
+                max_y = p0.y;
             }
-//  Indicate latched connections
-//            if (false) {
-//                int j = patch.objectinstances.indexOf(i.axoObj);
-//                if (j <= lastSource) {
-//                    int x = (p0.x + p1.x) / 2;
-//                    int y = (int) (0.5f * (p0.y + p1.y) + Math.abs(p1.y - p0.y) * 0.3f + Math.abs(p1.x - p0.x) * 0.05f);
-//                    g2.fillOval(x - 5, y - 5, 10, 10);
-//                }
-//            }
+
+            for (InletInstance i : dest) {
+                Point p1 = i.getJackLocInCanvas();
+                min_x = Math.min(min_x, p1.x);
+                min_y = Math.min(min_y, p1.y);
+                max_x = Math.max(max_x, p1.x);
+                max_y = Math.max(max_y, p1.y);
+            }
+            for (OutletInstance i : source) {
+                Point p1 = i.getJackLocInCanvas();
+                min_x = Math.min(min_x, p1.x);
+                min_y = Math.min(min_y, p1.y);
+                max_x = Math.max(max_x, p1.x);
+                max_y = Math.max(max_y, p1.y);
+            }
+
+            int fudge = Math.max((max_x - min_x) / 8, (max_y - min_y) / 8);
+            this.setLocation(new Point(min_x - fudge, min_y - fudge));
+            this.setSize(Math.max(1, max_x - min_x + (2 * fudge)), 
+                    Math.max(1, max_y - min_y + (2 * fudge)));
+        } catch (IllegalComponentStateException e) {
+
         }
     }
 

--- a/src/main/java/axoloti/ObjectSearchFrame.java
+++ b/src/main/java/axoloti/ObjectSearchFrame.java
@@ -22,7 +22,6 @@ import axoloti.object.AxoObjectInstanceAbstract;
 import axoloti.object.AxoObjectTreeNode;
 import axoloti.utils.Constants;
 import java.awt.Color;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.event.ComponentAdapter;
@@ -86,7 +85,7 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
                 if (node.getUserObject() instanceof AxoObjectTreeNode) {
                     AxoObjectTreeNode anode = (AxoObjectTreeNode) node.getUserObject();
                     jPanel1.removeAll();
-                    jPanel1.repaint();
+                    jPanel1.setVisible(false);
                     jTextPane1.setText(anode.description);
                     jTextPane1.setCaretPosition(0);
                     previewObj = null;
@@ -264,8 +263,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
             public void componentShown(ComponentEvent e) {
                 if(inst != null) {
                     ObjectSearchFrame.this.scalePreviewPanel(inst.getWidth(), inst.getHeight());
-                    jPanel1.revalidate();
-                    jPanel1.repaint();
                 }
             }
         });
@@ -323,7 +320,7 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
             previewObj = null;
             type = null;
             jPanel1.removeAll();
-            jPanel1.repaint();
+            jPanel1.setVisible(false);
             return;
         }
         if (o != previewObj) {
@@ -336,11 +333,9 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
             inst = o.CreateInstance(null, "dummy", new Point(5, 5));
             jPanel1.removeAll();
             jPanel1.add(inst);
+            jPanel1.setVisible(true);
             jPanel1.doLayout();
             scalePreviewPanel(inst.getWidth(), inst.getHeight());
-
-            jPanel1.revalidate();
-            jPanel1.repaint();
 
             jTextPane1.setText(o.sDescription + "\n<p>\nPath: " + o.sPath + "\n<p>\nAuthor: " + o.sAuthor + "\n<p>\nLicense: " + o.sLicense);
             jTextPane1.setCaretPosition(0);
@@ -352,6 +347,8 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
         panelSize.width = (int) Math.round(originalWidth * p.zoomUI.getScale());
         panelSize.height = (int) Math.round(originalHeight * p.zoomUI.getScale());
         jPanel1.setPreferredSize(panelSize);
+        jPanel1.revalidate();
+        jPanel1.repaint();
     }
 
     static DefaultMutableTreeNode PopulateJTree(AxoObjectTreeNode anode, DefaultMutableTreeNode root) {
@@ -425,8 +422,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
                 }
             }
             jList1.setListData(listData.toArray());
-//            jList1.doLayout();
-//            jList1.revalidate();
             if (!listData.isEmpty()) {
                 type = listData.get(0);
                 jList1.setSelectedIndex(0);
@@ -448,7 +443,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
     void Cancel() {
         accepted = false;
         setVisible(false);
-        p.repaint();
     }
 
     void Accept() {
@@ -472,7 +466,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
                 }
             }
             setVisible(false);
-            p.repaint();
         }
     }
 
@@ -521,9 +514,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
         jPanel2.setLayout(new javax.swing.BoxLayout(jPanel2, javax.swing.BoxLayout.PAGE_AXIS));
 
         jTextFieldObjName.setAlignmentX(0.0F);
-        jTextFieldObjName.setMaximumSize(new java.awt.Dimension(10000, 20));
-        jTextFieldObjName.setMinimumSize(new java.awt.Dimension(100, 20));
-        jTextFieldObjName.setPreferredSize(new java.awt.Dimension(100, 20));
         jTextFieldObjName.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jTextFieldObjNameActionPerformed(evt);
@@ -540,7 +530,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
         jList1.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
         jList1.setAlignmentX(0.0F);
         jList1.setMaximumSize(null);
-        jList1.setMinimumSize(new java.awt.Dimension(100, 50));
         jList1.setVisibleRowCount(6);
         jScrollPane3.setViewportView(jList1);
 
@@ -550,7 +539,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
 
         jTree1.setAlignmentX(0.0F);
         jTree1.setDragEnabled(true);
-        jTree1.setMinimumSize(new java.awt.Dimension(100, 50));
         jTree1.setRootVisible(false);
         jScrollPane1.setViewportView(jTree1);
 
@@ -572,7 +560,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
 
         jPanel1.setBackground(java.awt.Color.lightGray);
         jPanel1.setEnabled(false);
-        jPanel1.setFocusTraversalKeysEnabled(false);
         jPanel1.setFocusable(false);
         jPanel1.setLayout(new java.awt.FlowLayout(java.awt.FlowLayout.LEFT, 0, 0));
         jLayeredPane1.add(jPanel1);
@@ -587,7 +574,6 @@ public class ObjectSearchFrame extends javax.swing.JFrame {
 
         jTextPane1.setEditable(false);
         jTextPane1.setFocusCycleRoot(false);
-        jTextPane1.setFocusTraversalKeysEnabled(false);
         jTextPane1.setFocusable(false);
         jTextPane1.setRequestFocusEnabled(false);
         jScrollPane4.setViewportView(jTextPane1);

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -460,7 +460,7 @@ public class Patch {
         }
         return null;
     }
-
+    
     /*
      private boolean CompatType(DataType source, DataType d2){
      if (d1 == d2) return true;
@@ -587,7 +587,6 @@ public class Patch {
                     delete(n);
                 }
                 SetDirty();
-                repaint();
                 return n;
             }
         } else {
@@ -600,7 +599,6 @@ public class Patch {
         if (!IsLocked()) {
             nets.remove(n);
             SetDirty();
-            repaint();
             return n;
         } else {
             Logger.getLogger(Patch.class.getName()).log(Level.INFO, "Can''t disconnect: locked!");
@@ -629,7 +627,6 @@ public class Patch {
             }
         }
         SetDirty();
-        repaint();
         objectinstances.remove(o);
         o.getType().DeleteInstance(o);
     }
@@ -672,7 +669,6 @@ public class Patch {
                     }
                 }
             }
-            repaint();
         } else {
             Logger.getLogger(Patch.class.getName()).log(Level.INFO, "Can't delete: locked!");
         }
@@ -727,6 +723,10 @@ public class Patch {
             this.nets = p.nets;
             this.cleanDanglingStates = false;
             this.PostContructor();
+            repaint();
+            for(Net n : nets) {
+                n.updateBounds();
+            }
             repaint();
         } catch (Exception ex) {
             Logger.getLogger(AxoObjects.class.getName()).log(Level.SEVERE, null, ex);
@@ -2373,7 +2373,6 @@ public class Patch {
                 new_obj.attributeInstances = old_obj.attributeInstances;
             }
             obj1.setName(n);
-            obj1.repaint();
             return obj1;
         } else if (obj instanceof AxoObjectInstanceZombie) {
             String n = obj.getInstanceName();
@@ -2386,7 +2385,6 @@ public class Patch {
                 new_obj.inletInstances = old_obj.inletInstances;
             }
             obj1.setName(n);
-            obj1.repaint();
             return obj1;
         }
         return obj;

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -177,7 +177,9 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         if (USBBulkConnection.GetConnection().isConnected()) {
             ShowConnect();
         }
+        createBufferStrategy(2);
     }
+
     QCmdProcessor qcmdprocessor;
 
     public void SetLive(boolean b) {
@@ -994,17 +996,14 @@ jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
 
     private void zoomInMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zoomInMenuItemActionPerformed
         patch.handleZoom(Constants.ZOOM_ACTION.IN, new Point(0, 0));
-        patch.Layers.repaint();
     }//GEN-LAST:event_zoomInMenuItemActionPerformed
 
     private void zoomDefaultMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zoomDefaultMenuItemActionPerformed
         patch.handleZoom(Constants.ZOOM_ACTION.DEFAULT, new Point(0, 0));
-        patch.Layers.repaint();
     }//GEN-LAST:event_zoomDefaultMenuItemActionPerformed
 
     private void zoomOutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_zoomOutMenuItemActionPerformed
         patch.handleZoom(Constants.ZOOM_ACTION.OUT, new Point(0, 0));
-        patch.Layers.repaint();
     }//GEN-LAST:event_zoomOutMenuItemActionPerformed
 
     private void undoItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_undoItemActionPerformed

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -155,7 +155,6 @@ public class PatchGUI extends Patch {
         Layers.setBackground(Theme.getCurrentTheme().Patch_Unlocked_Background);
         Layers.setOpaque(true);
         Layers.invalidate();
-        Layers.repaint();
         Layers.doLayout();
 
         TransferHandler TH = new TransferHandler() {
@@ -429,10 +428,11 @@ public class PatchGUI extends Patch {
                     int ymin = y1 < y2 ? y1 : y2;
                     int ymax = y1 > y2 ? y1 : y2;
                     selectionrectangle.setLocation(xmin, ymin);
-                    selectionrectangle.setSize(xmax - xmin, ymax - ymin);
+                    int width = xmax - xmin;
+                    int height = ymax - ymin;
+                    selectionrectangle.setSize(width, height);
                     selectionrectangle.setVisible(true);
-                    PatchGUI.this.selectionRectLayer.revalidate();
-                    PatchGUI.this.selectionRectLayer.repaint();
+                    selectionRectLayer.repaint(new Rectangle(xmin, ymin, width, height));
                 } else if (Button2down) {
                     handlePan(ev);
                 }
@@ -446,8 +446,6 @@ public class PatchGUI extends Patch {
             }
         });
         Layers.setVisible(true);
-        Layers.invalidate();
-        Layers.repaint();
 
         DropTarget dt;
         dt = new DropTarget() {
@@ -459,6 +457,9 @@ public class PatchGUI extends Patch {
                         NetDragging nd = (NetDragging) cmp;
                         nd.SetDragPoint(dtde.getLocation());
                         selectionRectLayerPanel.repaint();
+                        Rectangle bounds = nd.getBounds();
+                        zoomUI.scale(bounds);
+                        selectionRectLayerPanel.repaint(bounds);
                         break;
                     }
                 }
@@ -549,7 +550,7 @@ public class PatchGUI extends Patch {
             vertical.setValue(newVerticalValue);
         }
     }
-
+    
     public void handleZoom(Constants.ZOOM_ACTION action, Point origin) {
         // this method implements zoom to mouse functionality
         // we perform the scale change
@@ -893,7 +894,6 @@ public class PatchGUI extends Patch {
             }
             if (isUpdate) {
                 AdjustSize();
-                Layers.repaint();
                 SetDirty();
             }
         } else {
@@ -944,7 +944,7 @@ public class PatchGUI extends Patch {
     @Override
     public Net disconnect(IoletAbstract io) {
         Net n = super.disconnect(io);
-        Layers.repaint();
+        netLayerPanel.repaint();
         return n;
     }
 
@@ -953,8 +953,8 @@ public class PatchGUI extends Patch {
         Net nn = super.delete(n);
         if (nn != null) {
             netLayerPanel.remove(n);
-            Layers.repaint();
         }
+        netLayerPanel.repaint();
         return nn;
     }
 
@@ -962,7 +962,8 @@ public class PatchGUI extends Patch {
     public void delete(AxoObjectInstanceAbstract o) {
         super.delete(o);
         objectLayerPanel.remove(o);
-        Layers.repaint();
+        this.repaint();
+        AdjustSize();
     }
 
     @Override
@@ -1024,7 +1025,6 @@ public class PatchGUI extends Patch {
 
     @Override
     public void repaint() {
-        super.repaint();
         Layers.repaint();
     }
 

--- a/src/main/java/axoloti/ZoomUtils.java
+++ b/src/main/java/axoloti/ZoomUtils.java
@@ -1,15 +1,18 @@
 package axoloti;
 
 import axoloti.object.AxoObjectInstanceAbstract;
+import axoloti.utils.Constants;
+import axoloti.utils.LRUCache;
 import java.awt.Component;
-import java.awt.Container;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import javax.swing.JLayer;
 import javax.swing.JPopupMenu;
 import javax.swing.SwingUtilities;
 
 public class ZoomUtils {
+
     public static void showZoomedPopupMenu(Component component, AxoObjectInstanceAbstract axoObj, JPopupMenu m) {
         PatchGUI patchGUI = ((PatchGUI) axoObj.getPatch());
         double zoom = patchGUI.zoomUI.getScale();
@@ -18,33 +21,75 @@ public class ZoomUtils {
 
         menuLocation.x *= zoom;
         menuLocation.y *= zoom;
-        
+
         m.show(patchGUI.Layers, menuLocation.x, (int) Math.round(menuLocation.y + (component.getHeight() * zoom - 1)));
     }
-    
-    public static Point getToolTipLocation(Component component, MouseEvent event, AxoObjectInstanceAbstract axoObj) {
-        PatchGUI patchGUI = ((PatchGUI) axoObj.getPatch());
-        double zoom = ((PatchGUI) axoObj.getPatch()).zoomUI.getScale();
-        Point p = component.getLocationOnScreen();
 
-        SwingUtilities.convertPointFromScreen(p, patchGUI.Layers);
-        
-        p.x *= zoom;
-        p.y *= zoom;
-        
-        p = SwingUtilities.convertPoint(patchGUI.Layers, p, component.getParent());
-        
-        int widthOffset = (int) Math.round(component.getParent().getWidth() / 8 * zoom + 1);
-        int heightOffset = (int) Math.round(component.getParent().getHeight() / 2 * zoom + 1);
-        
-        return new Point(p.x + widthOffset, p.y + heightOffset);
+    public static Point getToolTipLocation(Component component, MouseEvent event, AxoObjectInstanceAbstract axoObj) {
+        if (axoObj != null) {
+            PatchGUI patchGUI = ((PatchGUI) axoObj.getPatch());
+            double zoom = ((PatchGUI) axoObj.getPatch()).zoomUI.getScale();
+            Point p = component.getLocationOnScreen();
+
+            SwingUtilities.convertPointFromScreen(p, patchGUI.Layers);
+
+            p.x *= zoom;
+            p.y *= zoom;
+
+            p = SwingUtilities.convertPoint(patchGUI.Layers, p, component.getParent());
+
+            int widthOffset = (int) Math.round(component.getParent().getWidth() / 8 * zoom + 1);
+            int heightOffset = (int) Math.round(component.getParent().getHeight() / 2 * zoom + 1);
+
+            return new Point(p.x + widthOffset, p.y + heightOffset);
+        }
+        return null;
+    }
+
+    private static final LRUCache<Component, JLayer> ANCESTOR_CACHE = new LRUCache<Component, JLayer>(Constants.ANCESTOR_CACHE_SIZE);
+
+    private static JLayer getAncestorLayer(Component c) {
+        JLayer ancestor = ANCESTOR_CACHE.get(c);
+        if (ancestor == null) {
+            ancestor = (JLayer) SwingUtilities.getAncestorOfClass(JLayer.class, c);
+            ANCESTOR_CACHE.put(c, ancestor);
+        }
+        return ancestor;
+    }
+
+    public static void paintObjectLayer(Component component) {
+        JLayer layer = getAncestorLayer(component);
+        if (layer != null) {
+            ZoomUI zoomUI = ((ZoomUI) layer.getUI());
+            paintObjectLayer(layer, component, zoomUI);
+        }
+    }
+
+    public static void paintObjectLayer(JLayer layer, Component component, ZoomUI zoomUI) {
+        paintObjectLayer(layer, component, zoomUI, true);
     }
     
-    public static void paintObjectLayer(Component component) {
-        Container c = SwingUtilities.getAncestorOfClass(JLayer.class, component);
-        if (c != null) {
-            c.revalidate();
-            c.repaint();
+    public static void paintObjectLayer(JLayer layer, Component component, ZoomUI zoomUI, boolean convert) {
+        if(layer == null) {
+            layer = getAncestorLayer(component);
+        }
+        
+        if (layer != null) {
+            Rectangle bounds = component.getBounds();
+            if(convert) {
+                bounds = SwingUtilities.convertRectangle(component, bounds, layer);
+                layer.repaint(bounds.x,
+                        bounds.y,
+                        bounds.width,
+                        bounds.height);
+            }
+            
+            zoomUI.scale(bounds);
+            
+            layer.repaint(bounds.x,
+                    bounds.y,
+                    bounds.width,
+                    bounds.height);
         }
     }
 }

--- a/src/main/java/axoloti/dialogs/PreferencesFrame.java
+++ b/src/main/java/axoloti/dialogs/PreferencesFrame.java
@@ -19,7 +19,6 @@ package axoloti.dialogs;
 
 import axoloti.Axoloti;
 import axoloti.MainFrame;
-import axoloti.menus.WindowMenu;
 import axoloti.utils.AxoFileLibrary;
 import axoloti.utils.AxoGitLibrary;
 import axoloti.utils.AxolotiLibrary;

--- a/src/main/java/axoloti/iolet/IoletAbstract.java
+++ b/src/main/java/axoloti/iolet/IoletAbstract.java
@@ -13,6 +13,7 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
@@ -130,17 +131,11 @@ public abstract class IoletAbstract extends JPanel {
     }
 
     public Point getJackLocInCanvas() {
-        Point p1 = new Point(5, 5);
-        Component p = (Component) jack;
-        while (p != null) {
-            p1.x = p1.x + p.getX();
-            p1.y = p1.y + p.getY();
-            if (p == axoObj) {
-                break;
-            }
-            p = (Component) p.getParent();
-        }
-        return p1;
+        Point jackLocation = jack.getLocationOnScreen();
+        jackLocation.x += 5;
+        jackLocation.y += 5;
+        SwingUtilities.convertPointFromScreen(jackLocation, getPatchGui().Layers);
+        return jackLocation;
     }
 
     public DropTarget createDropTarget() {
@@ -162,7 +157,7 @@ public abstract class IoletAbstract extends JPanel {
                             SwingUtilities.convertPointFromScreen(jackLocation, p.Layers);
                             jackLocation.x *= zoom;
                             jackLocation.y *= zoom;
-                            
+
                             Point pl = new Point(dtde.getLocation().x + jackLocation.x, dtde.getLocation().y + jackLocation.y);
                             drag_net.SetDragPoint(pl);
                         }
@@ -326,6 +321,11 @@ public abstract class IoletAbstract extends JPanel {
             Net n = axoObj.patch.GetNet(this);
             if (n != null) {
                 n.setSelected(highlighted);
+
+                final PatchGUI patchGUI = getPatchGui();
+                Rectangle bounds = n.getBounds();
+                patchGUI.zoomUI.scale(bounds);
+                patchGUI.netLayerPanel.repaint(bounds);
             }
         }
     }

--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -157,7 +157,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             if ((o1 != null) && (o1 != this)) {
                 Logger.getLogger(AxoObjectInstanceAbstract.class.getName()).log(Level.SEVERE, "Object name {0} already exists!", InstanceName);
                 doLayout();
-                repaint();
                 return;
             }
         }
@@ -166,9 +165,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             InstanceLabel.setText(InstanceName);
         }
         doLayout();
-        if (getParent() != null) {
-            getParent().repaint();
-        }
     }
 
     public AxoObjectAbstract getType() {
@@ -226,13 +222,10 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Unselected));
         setOpaque(true);
         resolveType();
-        
+
         setBackground(Theme.getCurrentTheme().Object_Default_Background);
-        
 
         setVisible(true);
-        revalidate();
-        repaint();
 
         popup = new JPopupMenu();
 
@@ -243,11 +236,9 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     if (me.getClickCount() == 1) {
                         if (me.isShiftDown()) {
                             SetSelected(!GetSelected());
-                            ((PatchGUI) patch).repaint();
                         } else if (Selected == false) {
                             ((PatchGUI) patch).SelectNone();
                             SetSelected(true);
-                            ((PatchGUI) patch).repaint();
                         }
                     }
                     if (me.getClickCount() == 2) {
@@ -389,7 +380,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         super.setLocation(x, y);
         this.x = x;
         this.y = y;
-
         if (patch != null) {
             patch.repaint();
         }
@@ -408,7 +398,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
     public void addInstanceNameEditor() {
         InstanceNameTF = new TextFieldComponent(InstanceName);
         InstanceNameTF.selectAll();
-//        InstanceNameTF.setInputVerifier(new AxoObjectInstanceNameVerifier());
         InstanceNameTF.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
@@ -423,7 +412,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                 String s = InstanceNameTF.getText();
                 setInstanceName(s);
                 getParent().remove(InstanceNameTF);
-                patch.repaint();
             }
 
             @Override
@@ -446,7 +434,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     setInstanceName(s);
                     getParent().remove(InstanceNameTF);
                 }
-                getParent().repaint();
             }
         });
 
@@ -455,7 +442,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         InstanceNameTF.setSize(getWidth(), 15);
         InstanceNameTF.setVisible(true);
         InstanceNameTF.requestFocus();
-        //patch.repaint();
     }
 
     /*
@@ -537,7 +523,6 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             } else {
                 setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Unselected));
             }
-            repaint();
         }
         this.Selected = Selected;
     }

--- a/src/main/java/axoloti/object/AxoObjectInstanceComment.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceComment.java
@@ -31,7 +31,6 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
 import javax.swing.BoxLayout;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Root;
@@ -88,11 +87,9 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
                     if (me.getClickCount() == 1) {
                         if (me.isShiftDown()) {
                             SetSelected(!GetSelected());
-                            ((PatchGUI) patch).repaint();
                         } else if (Selected == false) {
                             ((PatchGUI) patch).SelectNone();
                             SetSelected(true);
-                            ((PatchGUI) patch).repaint();
                         }
                     }
                 }
@@ -141,7 +138,6 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
                 String s = InstanceNameTF.getText();
                 setInstanceName(s);
                 getParent().remove(InstanceNameTF);
-                patch.repaint();
             }
 
             @Override
@@ -163,7 +159,6 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
                     String s = InstanceNameTF.getText();
                     setInstanceName(s);
                     getParent().remove(InstanceNameTF);
-                    patch.repaint();
                 }
             }
         });
@@ -181,9 +176,6 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
             InstanceLabel.setText(commentText);
         }
         doLayout();
-        if (getParent() != null) {
-            getParent().repaint();
-        }
         resizeToGrid();
     }
 

--- a/src/main/java/axoloti/object/AxoObjectInstanceHyperlink.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceHyperlink.java
@@ -111,11 +111,9 @@ public class AxoObjectInstanceHyperlink extends AxoObjectInstanceAbstract {
                     if (e.getClickCount() == 1) {
                         if (e.isShiftDown()) {
                             SetSelected(!GetSelected());
-                            ((PatchGUI) patch).repaint();
                         } else if (Selected == false) {
                             ((PatchGUI) patch).SelectNone();
                             SetSelected(true);
-                            ((PatchGUI) patch).repaint();
                         }
                     }
                 }

--- a/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
@@ -134,9 +134,7 @@ public class AxoObjectInstanceZombie extends AxoObjectInstanceAbstract {
     @Override
     public void setInstanceName(String s) {
         super.setInstanceName(s);
-//        InstanceLabel.doLayout();
         resizeToGrid();
-        repaint();
     }
 
     @Override

--- a/src/main/java/axoloti/utils/Constants.java
+++ b/src/main/java/axoloti/utils/Constants.java
@@ -42,4 +42,6 @@ public class Constants {
     public static final String OBJECT_LAYER_PANEL = "OBJECT_LAYER_PANEL";
     
     public static enum ZOOM_ACTION { IN, OUT, DEFAULT };
+    
+    public static final int ANCESTOR_CACHE_SIZE = 1024;
 }

--- a/src/main/java/axoloti/utils/LRUCache.java
+++ b/src/main/java/axoloti/utils/LRUCache.java
@@ -1,0 +1,82 @@
+package axoloti.utils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+* An LRU cache, based on <code>LinkedHashMap</code>.
+*
+* <p>
+* This cache has a fixed maximum number of elements (<code>cacheSize</code>).
+* If the cache is full and another entry is added, the LRU (least recently used) entry is dropped.
+*
+* <p>
+* This class is thread-safe. All methods of this class are synchronized.
+*
+* <p>
+* Author: Christian d'Heureuse, Inventec Informatik AG, Zurich, Switzerland<br>
+* Multi-licensed: EPL / LGPL / GPL / AL / BSD.
+*/
+public class LRUCache<K,V> {
+
+private static final float   hashTableLoadFactor = 0.75f;
+
+private LinkedHashMap<K,V>   map;
+private int                  cacheSize;
+
+/**
+* Creates a new LRU cache.
+* @param cacheSize the maximum number of entries that will be kept in this cache.
+*/
+public LRUCache (int cacheSize) {
+   this.cacheSize = cacheSize;
+   int hashTableCapacity = (int)Math.ceil(cacheSize / hashTableLoadFactor) + 1;
+   map = new LinkedHashMap<K,V>(hashTableCapacity, hashTableLoadFactor, true) {
+      // (an anonymous inner class)
+      private static final long serialVersionUID = 1;
+      @Override protected boolean removeEldestEntry (Map.Entry<K,V> eldest) {
+         return size() > LRUCache.this.cacheSize; }}; }
+
+/**
+* Retrieves an entry from the cache.<br>
+* The retrieved entry becomes the MRU (most recently used) entry.
+* @param key the key whose associated value is to be returned.
+* @return    the value associated to this key, or null if no value with this key exists in the cache.
+*/
+public synchronized V get (K key) {
+   return map.get(key); }
+
+/**
+* Adds an entry to this cache.
+* The new entry becomes the MRU (most recently used) entry.
+* If an entry with the specified key already exists in the cache, it is replaced by the new entry.
+* If the cache is full, the LRU (least recently used) entry is removed from the cache.
+* @param key    the key with which the specified value is to be associated.
+* @param value  a value to be associated with the specified key.
+*/
+public synchronized void put (K key, V value) {
+   map.put (key, value); }
+
+/**
+* Clears the cache.
+*/
+public synchronized void clear() {
+   map.clear(); }
+
+/**
+* Returns the number of used entries in the cache.
+* @return the number of entries currently in the cache.
+*/
+public synchronized int usedEntries() {
+   return map.size(); }
+
+/**
+* Returns a <code>Collection</code> that contains a copy of all cache entries.
+* @return a <code>Collection</code> with a copy of the cache content.
+*/
+public synchronized Collection<Map.Entry<K,V>> getAll() {
+   return new ArrayList<Map.Entry<K,V>>(map.entrySet()); }
+
+} // end class LRUCache

--- a/src/main/java/components/DropDownComponent.java
+++ b/src/main/java/components/DropDownComponent.java
@@ -114,8 +114,6 @@ public class DropDownComponent extends JComponent implements MouseListener {
             for (DDCListener il : ddcListeners) {
                 il.SelectionChanged();
             }
-            
-            repaint();
         }
     }
     


### PR DESCRIPTION
This PR improves the responsiveness of the patch ui by:
- avoiding unnecessary repaints
- trying to only paint regions of the canvas that actually need to be repainted
- changing the net rendering code such that nets are drawn relative to their own bounds rather than to the size of the patch (this was resulting in many unnecessary net repaint calls because all nets overlapped even when drawing on nonoverlapping regions)