### PR TITLE
GUI: avoid cable highlight during robot drag

### DIFF
--- a/src/main/java/axoloti/Net.java
+++ b/src/main/java/axoloti/Net.java
@@ -128,6 +128,10 @@ public class Net extends JPanel {
             i.setHighlighted(selected);
         }
     }
+    
+    public boolean getSelected() {
+        return this.selected;
+    }
 
     public void connectInlet(InletInstance inlet) {
         if (inlet.GetObjectInstance().patch != patch) {

--- a/src/main/java/axoloti/iolet/IoletAbstract.java
+++ b/src/main/java/axoloti/iolet/IoletAbstract.java
@@ -317,9 +317,11 @@ public abstract class IoletAbstract extends JPanel {
     }
 
     public void setHighlighted(boolean highlighted) {
-        if (axoObj.patch != null) {
+        if (getRootPane().getCursor() != MainFrame.transparentCursor
+                && axoObj.patch != null) {
             Net n = axoObj.patch.GetNet(this);
-            if (n != null) {
+            if (n != null
+                    && n.getSelected() != highlighted) {
                 n.setSelected(highlighted);
 
                 final PatchGUI patchGUI = getPatchGui();


### PR DESCRIPTION
This PR eliminates the annoying problem of highlighted cables during robot drags. Also, we avoid repainting a net if its highlight state hasn't actually changed.