### PR TITLE
GUI: cross platform keyboard shortcuts

### DIFF
--- a/src/main/java/axoloti/PatchFrame.form
+++ b/src/main/java/axoloti/PatchFrame.form
@@ -67,9 +67,6 @@
           <SubComponents>
             <MenuItem class="javax.swing.JMenuItem" name="undoItem">
               <Properties>
-                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
-                  <KeyStroke key="Ctrl+Z"/>
-                </Property>
                 <Property name="text" type="java.lang.String" value="Undo"/>
               </Properties>
               <Events>
@@ -79,9 +76,6 @@
             </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="redoItem">
               <Properties>
-                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
-                  <KeyStroke key="Shift+Ctrl+Z"/>
-                </Property>
                 <Property name="text" type="java.lang.String" value="Redo"/>
               </Properties>
               <Events>
@@ -167,9 +161,6 @@
             </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="zoomInMenuItem">
               <Properties>
-                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
-                  <KeyStroke key="Ctrl+EQUALS"/>
-                </Property>
                 <Property name="text" type="java.lang.String" value="Zoom In"/>
               </Properties>
               <Events>
@@ -186,9 +177,6 @@
             </MenuItem>
             <MenuItem class="javax.swing.JMenuItem" name="zoomOutMenuItem">
               <Properties>
-                <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.editors.KeyStrokeEditor">
-                  <KeyStroke key="Ctrl+MINUS"/>
-                </Property>
                 <Property name="text" type="java.lang.String" value="Zoom Out"/>
               </Properties>
               <Events>

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -177,6 +177,18 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         if (USBBulkConnection.GetConnection().isConnected()) {
             ShowConnect();
         }
+        
+        this.undoItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, 
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        this.redoItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, 
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK));
+        this.zoomDefaultMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_0, 
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        this.zoomInMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, 
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        this.zoomOutMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, 
+                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+
         createBufferStrategy(2);
     }
 
@@ -445,7 +457,6 @@ jMenuClose.addActionListener(new java.awt.event.ActionListener() {
     jMenuEdit.setMnemonic('E');
     jMenuEdit.setText("Edit");
 
-    undoItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_Z, java.awt.event.InputEvent.CTRL_MASK));
     undoItem.setText("Undo");
     undoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
         public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
@@ -463,7 +474,6 @@ jMenuClose.addActionListener(new java.awt.event.ActionListener() {
     });
     jMenuEdit.add(undoItem);
 
-    redoItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_Z, java.awt.event.InputEvent.SHIFT_MASK | java.awt.event.InputEvent.CTRL_MASK));
     redoItem.setText("Redo");
     redoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
         public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
@@ -548,7 +558,6 @@ jMenuItemSelectAll.addActionListener(new java.awt.event.ActionListener() {
     jMenuView.add(jMenuItemAdjScroll);
     jMenuView.add(jSeparator5);
 
-    zoomInMenuItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_EQUALS, java.awt.event.InputEvent.CTRL_MASK));
     zoomInMenuItem.setText("Zoom In");
     zoomInMenuItem.addActionListener(new java.awt.event.ActionListener() {
         public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -565,7 +574,6 @@ jMenuItemSelectAll.addActionListener(new java.awt.event.ActionListener() {
     });
     jMenuView.add(zoomDefaultMenuItem);
 
-    zoomOutMenuItem.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_MINUS, java.awt.event.InputEvent.CTRL_MASK));
     zoomOutMenuItem.setText("Zoom Out");
     zoomOutMenuItem.addActionListener(new java.awt.event.ActionListener() {
         public void actionPerformed(java.awt.event.ActionEvent evt) {


### PR DESCRIPTION
Fix zoom and undo such that on Mac we use Command rather than Control. Also, add a CMD/Ctrl-0 shortcut to return to default zoom.