### PR TITLE
GUI: clean up alt modifier panning

### DIFF
--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -330,7 +330,6 @@ public class PatchGUI extends Patch {
                     panOrigin = Layers.getMousePosition();
                     if (panOrigin != null) {
                         zoomUI.removeZoomFactor(panOrigin);
-                        PatchGUI.this.patchframe.getRootPane().setCursor(new Cursor(Cursor.MOVE_CURSOR));
                         Button2down = true;
                         zoomUI.startPan();
                     }
@@ -530,6 +529,7 @@ public class PatchGUI extends Patch {
              @Override     
              public void mouseMoved(MouseEvent ev) {       
                  if (ev.isAltDown()) {     
+                     PatchGUI.this.patchframe.getRootPane().setCursor(new Cursor(Cursor.MOVE_CURSOR));
                      handlePan(ev);        
                  }     
              }     

--- a/src/main/java/axoloti/ZoomUI.java
+++ b/src/main/java/axoloti/ZoomUI.java
@@ -249,12 +249,25 @@ public class ZoomUI extends LayerUI<JComponent> {
         }
     }
 
-    protected void processKeyEvent(KeyEvent e,
+    @Override
+    protected void processKeyEvent(KeyEvent ke,
             JLayer<? extends JComponent> l) {
-        ZoomUtils.paintObjectLayer(l, e.getComponent(), this);
+        if(ke.getKeyCode() == KeyEvent.VK_ALT) {
+            KeyListener[] listeners = patch.Layers.getListeners(KeyListener.class);
+            for(KeyListener kl : listeners) {
+                if(ke.getID() == KeyEvent.KEY_PRESSED) {
+                    kl.keyPressed(getNewKeyEvent(ke));
+                }
+                else if(ke.getID() == KeyEvent.KEY_RELEASED) {
+                    kl.keyReleased(getNewKeyEvent(ke));
+                }
+            }
+        }
+        ZoomUtils.paintObjectLayer(l, ke.getComponent(), this);
     }
 
-    protected void proccesFocusEvent(FocusEvent e,
+    @Override
+    protected void processFocusEvent(FocusEvent e,
             JLayer<? extends JComponent> l) {
         ZoomUtils.paintObjectLayer(l, e.getComponent(), this);
     }
@@ -346,6 +359,10 @@ public class ZoomUI extends LayerUI<JComponent> {
         return new MouseEvent(component, eventId, mouseEvent.getWhen(), mouseEvent.getModifiers(),
                 mouseEvent.getX(), mouseEvent.getY(), mouseEvent.getXOnScreen(), mouseEvent.getYOnScreen(), mouseEvent.getClickCount(), mouseEvent.isPopupTrigger(),
                 mouseEvent.getButton());
+    }
+    
+    private KeyEvent getNewKeyEvent(KeyEvent keyEvent) {
+        return new KeyEvent(patch.Layers, keyEvent.getID(), keyEvent.getWhen(), keyEvent.getModifiers(), keyEvent.getKeyCode(), keyEvent.getKeyChar());
     }
 
     public double getScale() {


### PR DESCRIPTION
With Mark's latest commit, we've moved to a single modifier, ALT, to control zooming and panning. It is used in two ways: either to 1. allow zooming from mouse wheel events (from the trackpad or from a real mouse wheel) or 2. to allow smooth panning with a single finger drag or mouse motion. Without ALT, the trackpad has the default mouse wheel behavior.

This patch fixes two things:
1. We ensure that the drag cursor is only shown once a drag has actually started, not just when ALT is pressed.
2. Previously the ALT behavior wasn't handled correctly when a UI component implementing KeyListener was focused (DialComponent for example). We now route this event to the correct handler in the main JLayeredPane, so ALT panning works as expected everywhere in the canvas.