### PR TITLE
GUI: standardize on control or cmd modifier

### DIFF
--- a/src/main/java/axoloti/MainFrame.form
+++ b/src/main/java/axoloti/MainFrame.form
@@ -22,7 +22,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuItemCopy">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_C,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_C, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Copy"/>
               </Properties>
@@ -296,7 +296,7 @@
         <DimensionLayout dim="0">
           <Group type="103" groupAlignment="0" attributes="0">
               <Component id="jLabelCPUID" max="32767" attributes="0"/>
-              <Component id="jCheckBoxConnect" alignment="0" pref="151" max="32767" attributes="0"/>
+              <Component id="jCheckBoxConnect" alignment="0" max="32767" attributes="0"/>
               <Group type="102" alignment="0" attributes="0">
                   <Component id="jLabelVoltages" min="-2" max="-2" attributes="0"/>
                   <EmptySpace min="0" pref="0" max="32767" attributes="0"/>

--- a/src/main/java/axoloti/MainFrame.java
+++ b/src/main/java/axoloti/MainFrame.java
@@ -31,11 +31,11 @@ import axoloti.object.AxoObjects;
 import axoloti.usb.Usb;
 import axoloti.utils.AxolotiLibrary;
 import axoloti.utils.FirmwareID;
+import axoloti.utils.KeyUtils;
 import axoloti.utils.Preferences;
 import java.awt.Cursor;
 import java.awt.EventQueue;
 import java.awt.Point;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -449,7 +449,7 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
         jPanel1Layout.setHorizontalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addComponent(jLabelCPUID, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-            .addComponent(jCheckBoxConnect, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE)
+            .addComponent(jCheckBoxConnect, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(jPanel1Layout.createSequentialGroup()
                 .addComponent(jLabelVoltages)
                 .addGap(0, 0, Short.MAX_VALUE))
@@ -474,157 +474,156 @@ public final class MainFrame extends javax.swing.JFrame implements ActionListene
 
         jMenuEdit.setText("Edit");
 
-        jMenuItemCopy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C,
-            Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-    jMenuItemCopy.setText("Copy");
-    jMenuEdit.add(jMenuItemCopy);
+        jMenuItemCopy.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuItemCopy.setText("Copy");
+        jMenuEdit.add(jMenuItemCopy);
 
-    jMenuBar1.add(jMenuEdit);
+        jMenuBar1.add(jMenuEdit);
 
-    jMenuBoard.setText("Board");
+        jMenuBoard.setText("Board");
 
-    jMenuItemSelectCom.setText("Select Device...");
-    jMenuItemSelectCom.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemSelectComActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemSelectCom);
+        jMenuItemSelectCom.setText("Select Device...");
+        jMenuItemSelectCom.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemSelectComActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemSelectCom);
 
-    jMenuItemFConnect.setText("Connect");
-    jMenuItemFConnect.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFConnectActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemFConnect);
+        jMenuItemFConnect.setText("Connect");
+        jMenuItemFConnect.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFConnectActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemFConnect);
 
-    jMenuItemFDisconnect.setText("Disconnect");
-    jMenuItemFDisconnect.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFDisconnectActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemFDisconnect);
+        jMenuItemFDisconnect.setText("Disconnect");
+        jMenuItemFDisconnect.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFDisconnectActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemFDisconnect);
 
-    jMenuItemPing.setText("Ping");
-    jMenuItemPing.setEnabled(false);
-    jMenuItemPing.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemPingActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemPing);
+        jMenuItemPing.setText("Ping");
+        jMenuItemPing.setEnabled(false);
+        jMenuItemPing.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemPingActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemPing);
 
-    jMenuItemPanic.setText("Panic");
-    jMenuItemPanic.setEnabled(false);
-    jMenuItemPanic.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemPanicActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemPanic);
+        jMenuItemPanic.setText("Panic");
+        jMenuItemPanic.setEnabled(false);
+        jMenuItemPanic.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemPanicActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemPanic);
 
-    jMenuItemMount.setText("Enter card reader mode (disconnects editor)");
-    jMenuItemMount.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemMountActionPerformed(evt);
-        }
-    });
-    jMenuBoard.add(jMenuItemMount);
+        jMenuItemMount.setText("Enter card reader mode (disconnects editor)");
+        jMenuItemMount.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemMountActionPerformed(evt);
+            }
+        });
+        jMenuBoard.add(jMenuItemMount);
 
-    jMenuFirmware.setText("Firmware");
+        jMenuFirmware.setText("Firmware");
 
-    jMenuItemFlashDefault.setText("Flash");
-    jMenuItemFlashDefault.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFlashDefaultActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemFlashDefault);
+        jMenuItemFlashDefault.setText("Flash");
+        jMenuItemFlashDefault.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFlashDefaultActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemFlashDefault);
 
-    jMenuItemFlashDFU.setText("Flash (Rescue)");
-    jMenuItemFlashDFU.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFlashDFUActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemFlashDFU);
+        jMenuItemFlashDFU.setText("Flash (Rescue)");
+        jMenuItemFlashDFU.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFlashDFUActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemFlashDFU);
 
-    jMenuItemRefreshFWID.setText("Refresh Firmware ID");
-    jMenuItemRefreshFWID.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemRefreshFWIDActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemRefreshFWID);
-    jMenuFirmware.add(jDevSeparator);
+        jMenuItemRefreshFWID.setText("Refresh Firmware ID");
+        jMenuItemRefreshFWID.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemRefreshFWIDActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemRefreshFWID);
+        jMenuFirmware.add(jDevSeparator);
 
-    jMenuItemFCompile.setText("Compile");
-    jMenuItemFCompile.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFCompileActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemFCompile);
+        jMenuItemFCompile.setText("Compile");
+        jMenuItemFCompile.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFCompileActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemFCompile);
 
-    jMenuItemEnterDFU.setText("Enter Rescue mode");
-    jMenuItemEnterDFU.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemEnterDFUActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemEnterDFU);
+        jMenuItemEnterDFU.setText("Enter Rescue mode");
+        jMenuItemEnterDFU.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemEnterDFUActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemEnterDFU);
 
-    jMenuItemFlashSDR.setText("Flash (User)");
-    jMenuItemFlashSDR.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemFlashSDRActionPerformed(evt);
-        }
-    });
-    jMenuFirmware.add(jMenuItemFlashSDR);
+        jMenuItemFlashSDR.setText("Flash (User)");
+        jMenuItemFlashSDR.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemFlashSDRActionPerformed(evt);
+            }
+        });
+        jMenuFirmware.add(jMenuItemFlashSDR);
 
-    jMenuBoard.add(jMenuFirmware);
+        jMenuBoard.add(jMenuFirmware);
 
-    jMenuBar1.add(jMenuBoard);
-    jMenuBar1.add(windowMenu1);
+        jMenuBar1.add(jMenuBoard);
+        jMenuBar1.add(windowMenu1);
 
-    helpMenu1.setText("Help");
-    jMenuBar1.add(helpMenu1);
+        helpMenu1.setText("Help");
+        jMenuBar1.add(helpMenu1);
 
-    setJMenuBar(jMenuBar1);
+        setJMenuBar(jMenuBar1);
 
-    javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
-    getContentPane().setLayout(layout);
-    layout.setHorizontalGroup(
-        layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-        .addComponent(jScrollPaneLog)
-        .addComponent(jPanelProgress, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-        .addGroup(layout.createSequentialGroup()
-            .addContainerGap()
-            .addComponent(jLabelIcon, javax.swing.GroupLayout.PREFERRED_SIZE, 70, javax.swing.GroupLayout.PREFERRED_SIZE)
-            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-            .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-            .addGap(18, 88, Short.MAX_VALUE)
-            .addComponent(jButtonClear)
-            .addContainerGap())
-    );
-    layout.setVerticalGroup(
-        layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-        .addGroup(layout.createSequentialGroup()
-            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                .addGroup(layout.createSequentialGroup()
-                    .addContainerGap()
-                    .addComponent(jButtonClear))
-                .addComponent(jLabelIcon, javax.swing.GroupLayout.PREFERRED_SIZE, 59, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-            .addComponent(jScrollPaneLog, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE)
-            .addGap(0, 0, 0)
-            .addComponent(jPanelProgress, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-    );
+        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
+        getContentPane().setLayout(layout);
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addComponent(jScrollPaneLog)
+            .addComponent(jPanelProgress, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addComponent(jLabelIcon, javax.swing.GroupLayout.PREFERRED_SIZE, 70, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGap(18, 88, Short.MAX_VALUE)
+                .addComponent(jButtonClear)
+                .addContainerGap())
+        );
+        layout.setVerticalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(layout.createSequentialGroup()
+                        .addContainerGap()
+                        .addComponent(jButtonClear))
+                    .addComponent(jLabelIcon, javax.swing.GroupLayout.PREFERRED_SIZE, 59, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jPanel1, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jScrollPaneLog, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE)
+                .addGap(0, 0, 0)
+                .addComponent(jPanelProgress, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+        );
 
-    pack();
+        pack();
     }// </editor-fold>//GEN-END:initComponents
 
     private void jButtonClearActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButtonClearActionPerformed

--- a/src/main/java/axoloti/PatchFrame.form
+++ b/src/main/java/axoloti/PatchFrame.form
@@ -14,7 +14,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuSave">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_S,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Save"/>
               </Properties>
@@ -49,7 +49,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuClose">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_W,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_W, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Close"/>
               </Properties>
@@ -97,7 +97,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuItemSelectAll">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_A,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_A, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Select All"/>
               </Properties>
@@ -194,7 +194,7 @@
             <MenuItem class="javax.swing.JCheckBoxMenuItem" name="jCheckBoxMenuItemLive">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_E,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_E, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Live"/>
               </Properties>
@@ -239,7 +239,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuGenerateCode">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_G,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_G, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Generate code"/>
               </Properties>
@@ -250,7 +250,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuCompileCode">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_H,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_H, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Compile code"/>
               </Properties>
@@ -261,7 +261,7 @@
             <MenuItem class="javax.swing.JMenuItem" name="jMenuUploadCode">
               <Properties>
                 <Property name="accelerator" type="javax.swing.KeyStroke" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_J,&#xa;    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask())" type="code"/>
+                  <Connection code="KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyUtils.CONTROL_OR_CMD_MASK)" type="code"/>
                 </Property>
                 <Property name="text" type="java.lang.String" value="Upload code"/>
               </Properties>

--- a/src/main/java/axoloti/PatchFrame.java
+++ b/src/main/java/axoloti/PatchFrame.java
@@ -19,6 +19,7 @@ package axoloti;
 
 import axoloti.object.AxoObjects;
 import axoloti.utils.Constants;
+import axoloti.utils.KeyUtils;
 import components.PresetPanel;
 import components.VisibleCablePanel;
 import java.awt.Cursor;
@@ -91,7 +92,8 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
 
         JMenuItem menuItem = new JMenuItem(new DefaultEditorKit.CutAction());
         menuItem.setText("Cut");
-        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, 
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuEdit.add(menuItem);
         menuItem.addActionListener(new ActionListener() {
             @Override
@@ -117,7 +119,8 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         });
         menuItem = new JMenuItem(new DefaultEditorKit.CopyAction());
         menuItem.setText("Copy");
-        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, 
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuEdit.add(menuItem);
         menuItem.addActionListener(new ActionListener() {
             @Override
@@ -142,7 +145,8 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         });
         menuItem = new JMenuItem(new DefaultEditorKit.PasteAction());
         menuItem.setText("Paste");
-        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_V, 
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuEdit.add(menuItem);
         menuItem.addActionListener(new ActionListener() {
             @Override
@@ -184,15 +188,15 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         }
         
         this.undoItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, 
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         this.redoItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, 
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() | KeyEvent.SHIFT_DOWN_MASK));
+                KeyUtils.CONTROL_OR_CMD_MASK | KeyEvent.SHIFT_DOWN_MASK));
         this.zoomDefaultMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_0, 
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         this.zoomInMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_EQUALS, 
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         this.zoomOutMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, 
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
 
         createBufferStrategy(2);
     }
@@ -413,320 +417,313 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
         fileMenu1.setText("File");
         fileMenu1.add(jSeparator1);
 
-        jMenuSave.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
-            Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-    jMenuSave.setText("Save");
-    jMenuSave.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuSaveActionPerformed(evt);
-        }
-    });
-    fileMenu1.add(jMenuSave);
+        jMenuSave.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuSave.setText("Save");
+        jMenuSave.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuSaveActionPerformed(evt);
+            }
+        });
+        fileMenu1.add(jMenuSave);
 
-    jMenuSaveAs.setText("Save As...");
-    jMenuSaveAs.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuSaveAsActionPerformed(evt);
-        }
-    });
-    fileMenu1.add(jMenuSaveAs);
+        jMenuSaveAs.setText("Save As...");
+        jMenuSaveAs.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuSaveAsActionPerformed(evt);
+            }
+        });
+        fileMenu1.add(jMenuSaveAs);
 
-    jMenuSaveCopy.setText("Save Copy...");
-    jMenuSaveCopy.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuSaveCopyActionPerformed(evt);
-        }
-    });
-    fileMenu1.add(jMenuSaveCopy);
+        jMenuSaveCopy.setText("Save Copy...");
+        jMenuSaveCopy.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuSaveCopyActionPerformed(evt);
+            }
+        });
+        fileMenu1.add(jMenuSaveCopy);
 
-    jMenuSaveClip.setText("Save To Clipboard");
-    jMenuSaveClip.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuSaveClipActionPerformed(evt);
-        }
-    });
-    fileMenu1.add(jMenuSaveClip);
+        jMenuSaveClip.setText("Save To Clipboard");
+        jMenuSaveClip.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuSaveClipActionPerformed(evt);
+            }
+        });
+        fileMenu1.add(jMenuSaveClip);
 
-    jMenuClose.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jMenuClose.setText("Close");
-jMenuClose.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jMenuCloseActionPerformed(evt);
-    }
-    });
-    fileMenu1.add(jMenuClose);
+        jMenuClose.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuClose.setText("Close");
+        jMenuClose.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuCloseActionPerformed(evt);
+            }
+        });
+        fileMenu1.add(jMenuClose);
 
-    jMenuBar1.add(fileMenu1);
+        jMenuBar1.add(fileMenu1);
 
-    jMenuEdit.setMnemonic('E');
-    jMenuEdit.setText("Edit");
+        jMenuEdit.setMnemonic('E');
+        jMenuEdit.setText("Edit");
 
-    undoItem.setText("Undo");
-    undoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
-        public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
-            undoItemAncestorAdded(evt);
-        }
-        public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
-        }
-        public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
-        }
-    });
-    undoItem.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            undoItemActionPerformed(evt);
-        }
-    });
-    jMenuEdit.add(undoItem);
+        undoItem.setText("Undo");
+        undoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
+            public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
+                undoItemAncestorAdded(evt);
+            }
+            public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
+            }
+            public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
+            }
+        });
+        undoItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                undoItemActionPerformed(evt);
+            }
+        });
+        jMenuEdit.add(undoItem);
 
-    redoItem.setText("Redo");
-    redoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
-        public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
-            redoItemAncestorAdded(evt);
-        }
-        public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
-        }
-        public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
-        }
-    });
-    redoItem.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            redoItemActionPerformed(evt);
-        }
-    });
-    jMenuEdit.add(redoItem);
+        redoItem.setText("Redo");
+        redoItem.addAncestorListener(new javax.swing.event.AncestorListener() {
+            public void ancestorAdded(javax.swing.event.AncestorEvent evt) {
+                redoItemAncestorAdded(evt);
+            }
+            public void ancestorRemoved(javax.swing.event.AncestorEvent evt) {
+            }
+            public void ancestorMoved(javax.swing.event.AncestorEvent evt) {
+            }
+        });
+        redoItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                redoItemActionPerformed(evt);
+            }
+        });
+        jMenuEdit.add(redoItem);
 
-    jMenuItemDelete.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_DELETE, 0));
-    jMenuItemDelete.setText("Delete");
-    jMenuItemDelete.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemDeleteActionPerformed(evt);
-        }
-    });
-    jMenuEdit.add(jMenuItemDelete);
+        jMenuItemDelete.setAccelerator(javax.swing.KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_DELETE, 0));
+        jMenuItemDelete.setText("Delete");
+        jMenuItemDelete.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemDeleteActionPerformed(evt);
+            }
+        });
+        jMenuEdit.add(jMenuItemDelete);
 
-    jMenuItemSelectAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jMenuItemSelectAll.setText("Select All");
-jMenuItemSelectAll.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jMenuItemSelectAllActionPerformed(evt);
-    }
-    });
-    jMenuEdit.add(jMenuItemSelectAll);
+        jMenuItemSelectAll.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuItemSelectAll.setText("Select All");
+        jMenuItemSelectAll.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemSelectAllActionPerformed(evt);
+            }
+        });
+        jMenuEdit.add(jMenuItemSelectAll);
 
-    jMenuItemAddObj.setText("New Object...");
-    jMenuItemAddObj.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemAddObjActionPerformed(evt);
-        }
-    });
-    jMenuEdit.add(jMenuItemAddObj);
-    jMenuEdit.add(jSeparator4);
+        jMenuItemAddObj.setText("New Object...");
+        jMenuItemAddObj.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemAddObjActionPerformed(evt);
+            }
+        });
+        jMenuEdit.add(jMenuItemAddObj);
+        jMenuEdit.add(jSeparator4);
 
-    jMenuBar1.add(jMenuEdit);
+        jMenuBar1.add(jMenuEdit);
 
-    jMenuView.setMnemonic('V');
-    jMenuView.setText("View");
+        jMenuView.setMnemonic('V');
+        jMenuView.setText("View");
 
-    jMenuItemNotes.setText("Notes");
-    jMenuItemNotes.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemNotesActionPerformed(evt);
-        }
-    });
-    jMenuView.add(jMenuItemNotes);
+        jMenuItemNotes.setText("Notes");
+        jMenuItemNotes.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemNotesActionPerformed(evt);
+            }
+        });
+        jMenuView.add(jMenuItemNotes);
 
-    jMenuItemSettings.setText("Settings");
-    jMenuItemSettings.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemSettingsActionPerformed(evt);
-        }
-    });
-    jMenuView.add(jMenuItemSettings);
-    jMenuView.add(jSeparator2);
+        jMenuItemSettings.setText("Settings");
+        jMenuItemSettings.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemSettingsActionPerformed(evt);
+            }
+        });
+        jMenuView.add(jMenuItemSettings);
+        jMenuView.add(jSeparator2);
 
-    jCheckBoxMenuItemCordsInBackground.setText("Patch Cords In Background");
-    jCheckBoxMenuItemCordsInBackground.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jCheckBoxMenuItemCordsInBackgroundActionPerformed(evt);
-        }
-    });
-    jMenuView.add(jCheckBoxMenuItemCordsInBackground);
+        jCheckBoxMenuItemCordsInBackground.setText("Patch Cords In Background");
+        jCheckBoxMenuItemCordsInBackground.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jCheckBoxMenuItemCordsInBackgroundActionPerformed(evt);
+            }
+        });
+        jMenuView.add(jCheckBoxMenuItemCordsInBackground);
 
-    jMenuItemAdjScroll.setText("Adjust Scroll");
-    jMenuItemAdjScroll.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemAdjScrollActionPerformed(evt);
-        }
-    });
-    jMenuView.add(jMenuItemAdjScroll);
-    jMenuView.add(jSeparator5);
+        jMenuItemAdjScroll.setText("Adjust Scroll");
+        jMenuItemAdjScroll.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemAdjScrollActionPerformed(evt);
+            }
+        });
+        jMenuView.add(jMenuItemAdjScroll);
+        jMenuView.add(jSeparator5);
 
-    zoomInMenuItem.setText("Zoom In");
-    zoomInMenuItem.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            zoomInMenuItemActionPerformed(evt);
-        }
-    });
-    jMenuView.add(zoomInMenuItem);
+        zoomInMenuItem.setText("Zoom In");
+        zoomInMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                zoomInMenuItemActionPerformed(evt);
+            }
+        });
+        jMenuView.add(zoomInMenuItem);
 
-    zoomDefaultMenuItem.setText("Zoom to Default");
-    zoomDefaultMenuItem.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            zoomDefaultMenuItemActionPerformed(evt);
-        }
-    });
-    jMenuView.add(zoomDefaultMenuItem);
+        zoomDefaultMenuItem.setText("Zoom to Default");
+        zoomDefaultMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                zoomDefaultMenuItemActionPerformed(evt);
+            }
+        });
+        jMenuView.add(zoomDefaultMenuItem);
 
-    zoomOutMenuItem.setText("Zoom Out");
-    zoomOutMenuItem.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            zoomOutMenuItemActionPerformed(evt);
-        }
-    });
-    jMenuView.add(zoomOutMenuItem);
+        zoomOutMenuItem.setText("Zoom Out");
+        zoomOutMenuItem.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                zoomOutMenuItemActionPerformed(evt);
+            }
+        });
+        jMenuView.add(zoomOutMenuItem);
 
-    jMenuBar1.add(jMenuView);
+        jMenuBar1.add(jMenuView);
 
-    jMenuPatch.setMnemonic('P');
-    jMenuPatch.setText("Patch");
+        jMenuPatch.setMnemonic('P');
+        jMenuPatch.setText("Patch");
 
-    jCheckBoxMenuItemLive.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jCheckBoxMenuItemLive.setText("Live");
-jCheckBoxMenuItemLive.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jCheckBoxMenuItemLiveActionPerformed(evt);
-    }
-    });
-    jMenuPatch.add(jCheckBoxMenuItemLive);
+        jCheckBoxMenuItemLive.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_E, KeyUtils.CONTROL_OR_CMD_MASK));
+        jCheckBoxMenuItemLive.setText("Live");
+        jCheckBoxMenuItemLive.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jCheckBoxMenuItemLiveActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jCheckBoxMenuItemLive);
 
-    jMenuItemUploadSD.setText("Upload to SDCard");
-    jMenuItemUploadSD.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemUploadSDActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemUploadSD);
+        jMenuItemUploadSD.setText("Upload to SDCard");
+        jMenuItemUploadSD.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemUploadSDActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemUploadSD);
 
-    jMenuItemUploadSDStart.setText("Upload to SDCard as startup");
-    jMenuItemUploadSDStart.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemUploadSDStartActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemUploadSDStart);
+        jMenuItemUploadSDStart.setText("Upload to SDCard as startup");
+        jMenuItemUploadSDStart.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemUploadSDStartActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemUploadSDStart);
 
-    jMenuItemUploadInternalFlash.setText("Upload to internal flash");
-    jMenuItemUploadInternalFlash.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemUploadInternalFlashActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemUploadInternalFlash);
-    jMenuPatch.add(jSeparator3);
+        jMenuItemUploadInternalFlash.setText("Upload to internal flash");
+        jMenuItemUploadInternalFlash.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemUploadInternalFlashActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemUploadInternalFlash);
+        jMenuPatch.add(jSeparator3);
 
-    jMenuGenerateAndCompileCode.setText("Generate & Compile code");
-    jMenuGenerateAndCompileCode.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuGenerateAndCompileCodeActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuGenerateAndCompileCode);
+        jMenuGenerateAndCompileCode.setText("Generate & Compile code");
+        jMenuGenerateAndCompileCode.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuGenerateAndCompileCodeActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuGenerateAndCompileCode);
 
-    jMenuGenerateCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_G,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jMenuGenerateCode.setText("Generate code");
-jMenuGenerateCode.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jMenuGenerateCodeActionPerformed(evt);
-    }
-    });
-    jMenuPatch.add(jMenuGenerateCode);
+        jMenuGenerateCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_G, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuGenerateCode.setText("Generate code");
+        jMenuGenerateCode.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuGenerateCodeActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuGenerateCode);
 
-    jMenuCompileCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jMenuCompileCode.setText("Compile code");
-jMenuCompileCode.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jMenuCompileCodeActionPerformed(evt);
-    }
-    });
-    jMenuPatch.add(jMenuCompileCode);
+        jMenuCompileCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_H, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuCompileCode.setText("Compile code");
+        jMenuCompileCode.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuCompileCodeActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuCompileCode);
 
-    jMenuUploadCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_J,
-        Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-jMenuUploadCode.setText("Upload code");
-jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
-    public void actionPerformed(java.awt.event.ActionEvent evt) {
-        jMenuUploadCodeActionPerformed(evt);
-    }
-    });
-    jMenuPatch.add(jMenuUploadCode);
+        jMenuUploadCode.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_J, KeyUtils.CONTROL_OR_CMD_MASK));
+        jMenuUploadCode.setText("Upload code");
+        jMenuUploadCode.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuUploadCodeActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuUploadCode);
 
-    jMenuItemLock.setText("Lock");
-    jMenuItemLock.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemLockActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemLock);
+        jMenuItemLock.setText("Lock");
+        jMenuItemLock.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemLockActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemLock);
 
-    jMenuItemUnlock.setText("Unlock");
-    jMenuItemUnlock.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemUnlockActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemUnlock);
+        jMenuItemUnlock.setText("Unlock");
+        jMenuItemUnlock.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemUnlockActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemUnlock);
 
-    jMenuItemDumpMod.setText("Dump modulation matrix");
-    jMenuItemDumpMod.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemDumpModActionPerformed(evt);
-        }
-    });
-    jMenuPatch.add(jMenuItemDumpMod);
+        jMenuItemDumpMod.setText("Dump modulation matrix");
+        jMenuItemDumpMod.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemDumpModActionPerformed(evt);
+            }
+        });
+        jMenuPatch.add(jMenuItemDumpMod);
 
-    jMenuBar1.add(jMenuPatch);
+        jMenuBar1.add(jMenuPatch);
 
-    jMenuPreset.setText("Preset");
-    jMenuPreset.setEnabled(false);
+        jMenuPreset.setText("Preset");
+        jMenuPreset.setEnabled(false);
 
-    jMenuItemClearPreset.setText("Clear current preset");
-    jMenuItemClearPreset.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemClearPresetActionPerformed(evt);
-        }
-    });
-    jMenuPreset.add(jMenuItemClearPreset);
+        jMenuItemClearPreset.setText("Clear current preset");
+        jMenuItemClearPreset.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemClearPresetActionPerformed(evt);
+            }
+        });
+        jMenuPreset.add(jMenuItemClearPreset);
 
-    jMenuItemPresetCurrentToInit.setText("Copy current state to init");
-    jMenuItemPresetCurrentToInit.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemPresetCurrentToInitActionPerformed(evt);
-        }
-    });
-    jMenuPreset.add(jMenuItemPresetCurrentToInit);
+        jMenuItemPresetCurrentToInit.setText("Copy current state to init");
+        jMenuItemPresetCurrentToInit.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemPresetCurrentToInitActionPerformed(evt);
+            }
+        });
+        jMenuPreset.add(jMenuItemPresetCurrentToInit);
 
-    jMenuItemDifferenceToPreset.setText("Difference between current and init to preset");
-    jMenuItemDifferenceToPreset.addActionListener(new java.awt.event.ActionListener() {
-        public void actionPerformed(java.awt.event.ActionEvent evt) {
-            jMenuItemDifferenceToPresetActionPerformed(evt);
-        }
-    });
-    jMenuPreset.add(jMenuItemDifferenceToPreset);
+        jMenuItemDifferenceToPreset.setText("Difference between current and init to preset");
+        jMenuItemDifferenceToPreset.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jMenuItemDifferenceToPresetActionPerformed(evt);
+            }
+        });
+        jMenuPreset.add(jMenuItemDifferenceToPreset);
 
-    jMenuBar1.add(jMenuPreset);
-    jMenuBar1.add(windowMenu1);
+        jMenuBar1.add(jMenuPreset);
+        jMenuBar1.add(windowMenu1);
 
-    helpMenu1.setText("Help");
-    jMenuBar1.add(helpMenu1);
+        helpMenu1.setText("Help");
+        jMenuBar1.add(helpMenu1);
 
-    setJMenuBar(jMenuBar1);
+        setJMenuBar(jMenuBar1);
 
-    pack();
+        pack();
     }// </editor-fold>//GEN-END:initComponents
 
     private void jCheckBoxLiveActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jCheckBoxLiveActionPerformed

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -26,6 +26,7 @@ import axoloti.object.AxoObjectInstanceAbstract;
 import axoloti.object.AxoObjects;
 import axoloti.outlets.OutletInstance;
 import axoloti.utils.Constants;
+import axoloti.utils.KeyUtils;
 import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
@@ -230,11 +231,11 @@ public class PatchGUI extends Patch {
 
         InputMap inputMap = Layers.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_X,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "cut");
+                KeyUtils.CONTROL_OR_CMD_MASK), "cut");
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_C,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "copy");
+                KeyUtils.CONTROL_OR_CMD_MASK), "copy");
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_V,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "paste");
+                KeyUtils.CONTROL_OR_CMD_MASK), "paste");
 
         ActionMap map = Layers.getActionMap();
         map.put(TransferHandler.getCutAction().getValue(Action.NAME),
@@ -261,37 +262,37 @@ public class PatchGUI extends Patch {
                     ysteps = Constants.Y_GRID;
                 }
                 if ((ke.getKeyCode() == KeyEvent.VK_SPACE)
-                        || ((ke.getKeyCode() == KeyEvent.VK_N) && (!ke.isControlDown()) && (!ke.isMetaDown()))
-                        || ((ke.getKeyCode() == KeyEvent.VK_1) && (ke.isControlDown()))) {
+                        || ((ke.getKeyCode() == KeyEvent.VK_N) && !KeyUtils.isControlOrCommandDown(ke))
+                        || ((ke.getKeyCode() == KeyEvent.VK_1) && KeyUtils.isControlOrCommandDown(ke))) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
                         ShowClassSelector(p, null, null);
                     }
-                } else if (((ke.getKeyCode() == KeyEvent.VK_C) && (!ke.isControlDown()) && (!ke.isMetaDown()))
-                        || ((ke.getKeyCode() == KeyEvent.VK_5) && (ke.isControlDown()))) {
+                } else if (((ke.getKeyCode() == KeyEvent.VK_C) && !KeyUtils.isControlOrCommandDown(ke))
+                        || ((ke.getKeyCode() == KeyEvent.VK_5) &&  KeyUtils.isControlOrCommandDown(ke))) {
                     AxoObjectInstanceAbstract ao = AddObjectInstance(MainFrame.axoObjects.GetAxoObjectFromName(patchComment, null).get(0), Layers.getMousePosition());
                     ao.addInstanceNameEditor();
                     ke.consume();
-                } else if ((ke.getKeyCode() == KeyEvent.VK_I) && (!ke.isControlDown()) && (!ke.isMetaDown())) {
+                } else if ((ke.getKeyCode() == KeyEvent.VK_I) && !KeyUtils.isControlOrCommandDown(ke)) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
                         ShowClassSelector(p, null, patchInlet);
                     }
-                } else if ((ke.getKeyCode() == KeyEvent.VK_O) && (!ke.isControlDown()) && (!ke.isMetaDown())) {
+                } else if ((ke.getKeyCode() == KeyEvent.VK_O) && !KeyUtils.isControlOrCommandDown(ke)) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
                         ShowClassSelector(p, null, patchOutlet);
                     }
-                } else if ((ke.getKeyCode() == KeyEvent.VK_D) && (!ke.isControlDown()) && (!ke.isMetaDown())) {
+                } else if ((ke.getKeyCode() == KeyEvent.VK_D) && !KeyUtils.isControlOrCommandDown(ke)) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
                         ShowClassSelector(p, null, patchDisplay);
                     }
-                } else if ((ke.getKeyCode() == KeyEvent.VK_M) && (!ke.isControlDown()) && (!ke.isMetaDown())) {
+                } else if ((ke.getKeyCode() == KeyEvent.VK_M) && !KeyUtils.isControlOrCommandDown(ke)) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
@@ -301,7 +302,7 @@ public class PatchGUI extends Patch {
                             ShowClassSelector(p, null, patchMidi);
                         }
                     }
-                } else if ((ke.getKeyCode() == KeyEvent.VK_A) && (!ke.isControlDown()) && (!ke.isMetaDown())) {
+                } else if ((ke.getKeyCode() == KeyEvent.VK_A) && !KeyUtils.isControlOrCommandDown(ke)) {
                     Point p = Layers.getMousePosition();
                     ke.consume();
                     if (p != null) {
@@ -326,7 +327,7 @@ public class PatchGUI extends Patch {
                 } else if (ke.getKeyCode() == KeyEvent.VK_LEFT) {
                     MoveSelectedAxoObjInstances(Direction.LEFT, xsteps, ysteps);
                     ke.consume();
-                } else if (ke.getKeyCode() == KeyEvent.VK_ALT) {
+                } else if (KeyUtils.isKeyCodeControlOrCommand(ke)) {
                     panOrigin = Layers.getMousePosition();
                     if (panOrigin != null) {
                         zoomUI.removeZoomFactor(panOrigin);
@@ -338,7 +339,7 @@ public class PatchGUI extends Patch {
 
             @Override
             public void keyReleased(KeyEvent ke) {
-                if (ke.getKeyCode() == KeyEvent.VK_ALT) {
+                if (KeyUtils.isKeyCodeControlOrCommand(ke)) {
                     PatchGUI.this.patchframe.getRootPane().setCursor(Cursor.getDefaultCursor());
                     Button2down = false;
                     zoomUI.stopPan();
@@ -490,8 +491,8 @@ public class PatchGUI extends Patch {
         };
 
         Layers.addMouseWheelListener(new MouseWheelListener() {
-            public void mouseWheelMoved(MouseWheelEvent e) {
-                if (e.isAltDown()) {
+            public void mouseWheelMoved(MouseWheelEvent e) {                
+                if (KeyUtils.isControlOrCommandDown(e)) {
                     int notches = e.getWheelRotation();
                     Point origin = e.getPoint();
                     Constants.ZOOM_ACTION action = notches < 0 ? Constants.ZOOM_ACTION.IN : Constants.ZOOM_ACTION.OUT;
@@ -527,7 +528,7 @@ public class PatchGUI extends Patch {
 
             @Override
             public void mouseMoved(MouseEvent ev) {
-                if (ev.isAltDown()) {
+                if (KeyUtils.isControlOrCommandDown(ev)) {
                     PatchGUI.this.patchframe.getRootPane().setCursor(new Cursor(Cursor.MOVE_CURSOR));
                     handlePan(ev);
                 }

--- a/src/main/java/axoloti/ZoomUI.java
+++ b/src/main/java/axoloti/ZoomUI.java
@@ -3,6 +3,7 @@ package axoloti;
 import axoloti.object.AxoObjectInstance;
 import axoloti.object.TitleBarPanel;
 import axoloti.utils.Constants;
+import axoloti.utils.KeyUtils;
 import components.JackInputComponent;
 import components.JackOutputComponent;
 import components.LabelComponent;
@@ -35,6 +36,7 @@ public class ZoomUI extends LayerUI<JComponent> {
 
     private final PatchGUI patch;
 
+    private boolean anyMouseDown = false;
     private boolean button2down = false;
 
     public ZoomUI(double startingScale, double zoomAmount, double zoomMax, double zoomMin,
@@ -95,8 +97,10 @@ public class ZoomUI extends LayerUI<JComponent> {
         for (MouseListener listener : mouseListeners) {
             if (localEvent.getID() == MouseEvent.MOUSE_PRESSED) {
                 listener.mousePressed(transformedEvent);
+                anyMouseDown = true;
             } else if (localEvent.getID() == MouseEvent.MOUSE_RELEASED) {
                 ZoomUI.this.button2down = false;
+                anyMouseDown = false;
                 dragging = false;
                 patch.patchframe.getRootPane().setCursor(Cursor.getDefaultCursor());
                 listener.mouseReleased(transformedEvent);
@@ -106,6 +110,7 @@ public class ZoomUI extends LayerUI<JComponent> {
         }
         if (localEvent.getID() == MouseEvent.MOUSE_PRESSED
                 && transformedEvent.getComponent() instanceof DialComponent) {
+            anyMouseDown = true;
             // ensure that dial focus highlights are repainted
             if (previousDial != null
                     && previousDial != transformedEvent.getComponent()) {
@@ -172,6 +177,7 @@ public class ZoomUI extends LayerUI<JComponent> {
         if (component == null) {
             // avoid transparent cursor if release occurs outside patch bounds
             if (e.getID() == MouseEvent.MOUSE_RELEASED) {
+                anyMouseDown = false;
                 patch.patchframe.getRootPane().setCursor(Cursor.getDefaultCursor());
 
             }
@@ -252,7 +258,8 @@ public class ZoomUI extends LayerUI<JComponent> {
     @Override
     protected void processKeyEvent(KeyEvent ke,
             JLayer<? extends JComponent> l) {
-        if(ke.getKeyCode() == KeyEvent.VK_ALT) {
+        if(KeyUtils.isKeyCodeControlOrCommand(ke) && 
+                !anyMouseDown) {
             KeyListener[] listeners = patch.Layers.getListeners(KeyListener.class);
             for(KeyListener kl : listeners) {
                 if(ke.getID() == KeyEvent.KEY_PRESSED) {

--- a/src/main/java/axoloti/menus/FileMenu.java
+++ b/src/main/java/axoloti/menus/FileMenu.java
@@ -25,6 +25,7 @@ import axoloti.PatchGUI;
 import axoloti.dialogs.PatchBank;
 import axoloti.dialogs.PreferencesFrame;
 import axoloti.utils.AxolotiLibrary;
+import axoloti.utils.KeyUtils;
 import axoloti.utils.Preferences;
 import generatedobjects.GeneratedObjects;
 import java.awt.Toolkit;
@@ -79,7 +80,7 @@ public class FileMenu extends JMenu {
         jMenuAutoTest = new JMenuItem();
 
         jMenuNewPatch.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuNewPatch.setText("New patch");
         jMenuNewPatch.addActionListener(new java.awt.event.ActionListener() {
             @Override
@@ -99,7 +100,7 @@ public class FileMenu extends JMenu {
         insert(jMenuNewBank, pos++);
 
         jMenuOpen.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuOpen.setText("Open...");
         jMenuOpen.addActionListener(new java.awt.event.ActionListener() {
             @Override
@@ -177,7 +178,7 @@ public class FileMenu extends JMenu {
         add(jSeparator1);
 
         jMenuQuit.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+                KeyUtils.CONTROL_OR_CMD_MASK));
         jMenuQuit.setText("Quit");
         jMenuQuit.addActionListener(new java.awt.event.ActionListener() {
             @Override

--- a/src/main/java/axoloti/menus/WindowMenu.java
+++ b/src/main/java/axoloti/menus/WindowMenu.java
@@ -113,27 +113,22 @@ public class WindowMenu extends JMenu {
         jMenuWindow.removeAll();
         {
             WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe, "Axoloti");
-            //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
             jMenuWindow.add(a);
         }
         {
             WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe.getKeyboard(), "Keyboard");
-            //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
             jMenuWindow.add(a);
         }
         {
             WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe.getFilemanager(), "File Manager");
-            //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
             jMenuWindow.add(a);
         }
         {
             WindowMenuItem a = new WindowMenuItem(MainFrame.mainframe.getRemote(), "Remote");
-            //a.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
             jMenuWindow.add(a);
         }
 
         jMenuWindow.add(new JSeparator());
         PopulateDocuments(jMenuWindow, "", DocumentWindowList.GetList());
     }
-
 }

--- a/src/main/java/axoloti/utils/KeyUtils.java
+++ b/src/main/java/axoloti/utils/KeyUtils.java
@@ -1,0 +1,24 @@
+package axoloti.utils;
+
+import java.awt.Toolkit;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.KeyStroke;
+
+public class KeyUtils {
+    public static Boolean isKeyCodeControlOrCommand(KeyEvent ke) {
+        return KeyStroke.getKeyStrokeForEvent(ke).equals(
+                KeyStroke.getKeyStroke(ke.getKeyCode(), Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()))
+                || (ke.getKeyCode() == KeyEvent.VK_CONTROL || ke.getKeyCode() == KeyEvent.VK_META);
+    }
+    
+    public static Boolean isControlOrCommandDown(InputEvent me) {
+        return me.isMetaDown() || me.isControlDown();
+    }
+    
+    public static Boolean isIgnoreModifierDown(KeyEvent ke) {
+        return ke.isAltDown() || ke.isAltGraphDown() || ke.isControlDown() || ke.isMetaDown();
+    }
+    
+    public static final int CONTROL_OR_CMD_MASK = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+}

--- a/src/main/java/components/control/ACtrlComponent.java
+++ b/src/main/java/components/control/ACtrlComponent.java
@@ -20,6 +20,7 @@ package components.control;
 import axoloti.PatchGUI;
 import axoloti.ZoomUtils;
 import axoloti.object.AxoObjectInstance;
+import axoloti.utils.KeyUtils;
 import java.awt.Color;
 import java.awt.Point;
 import java.awt.Toolkit;
@@ -165,11 +166,11 @@ public abstract class ACtrlComponent extends JComponent {
         setTransferHandler(TH);
         InputMap inputMap = getInputMap(JComponent.WHEN_FOCUSED);
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_X,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "cut");
+                KeyUtils.CONTROL_OR_CMD_MASK), "cut");
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_C,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "copy");
+                KeyUtils.CONTROL_OR_CMD_MASK), "copy");
         inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_V,
-                Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()), "paste");
+                KeyUtils.CONTROL_OR_CMD_MASK), "paste");
 
         ActionMap map = getActionMap();
         map.put(TransferHandler.getCutAction().getValue(Action.NAME),

--- a/src/main/java/components/control/Checkbox4StatesComponent.java
+++ b/src/main/java/components/control/Checkbox4StatesComponent.java
@@ -18,6 +18,7 @@
 package components.control;
 
 import axoloti.Theme;
+import axoloti.utils.KeyUtils;
 import java.awt.BasicStroke;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -95,7 +96,7 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
 
     @Override
     public void keyPressed(KeyEvent ke) {
-        if (ke.isAltDown() || ke.isAltGraphDown() || ke.isControlDown() || ke.isMetaDown()) {
+        if (KeyUtils.isIgnoreModifierDown(ke)) {
             return;
         }
         switch (ke.getKeyCode()) {

--- a/src/main/java/components/control/CheckboxComponent.java
+++ b/src/main/java/components/control/CheckboxComponent.java
@@ -18,6 +18,7 @@
 package components.control;
 
 import axoloti.Theme;
+import axoloti.utils.KeyUtils;
 import java.awt.BasicStroke;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -104,7 +105,7 @@ public class CheckboxComponent extends ACtrlComponent {
 
     @Override
     public void keyPressed(KeyEvent ke) {
-        if (ke.isAltDown() || ke.isAltGraphDown() || ke.isControlDown() || ke.isMetaDown()) {
+        if (KeyUtils.isIgnoreModifierDown(ke)) {
             return;
         }
         switch (ke.getKeyCode()) {

--- a/src/main/java/components/control/DialComponent.java
+++ b/src/main/java/components/control/DialComponent.java
@@ -22,6 +22,7 @@ import axoloti.Theme;
 import axoloti.datatypes.ValueFrac32;
 import axoloti.realunits.NativeToReal;
 import axoloti.utils.Constants;
+import axoloti.utils.KeyUtils;
 import axoloti.utils.OSDetect;
 import java.awt.AWTException;
 import java.awt.BasicStroke;
@@ -107,7 +108,7 @@ public class DialComponent extends ACtrlComponent {
                 } else {
 
                     double t = tick;
-                    if (e.isShiftDown() || e.isControlDown()) {
+                    if (e.isShiftDown() || KeyUtils.isControlOrCommandDown(e)) {
                         t = t * 0.1;
                     }
                     v = value + t * ((int) Math.round((MousePressedCoordY - e.getYOnScreen()) / getScale()));
@@ -151,20 +152,16 @@ public class DialComponent extends ACtrlComponent {
         MousePressedBtn = MouseEvent.NOBUTTON;
     }
 
-    private boolean isControlDown(KeyEvent ke) {
-        return OSDetect.getOS() == OSDetect.OS.MAC ? ke.isAltDown() : ke.isControlDown();
-    }
-
     @Override
     public void keyPressed(KeyEvent ke) {
         if (isEnabled()) {
             double steps = tick;
             if (ke.isShiftDown()) {
                 steps = steps * 0.1; // mini steps!
-                if (isControlDown(ke)) {
+                if (KeyUtils.isControlOrCommandDown(ke)) {
                     steps = steps * 0.1; // micro steps!                
                 }
-            } else if (isControlDown(ke)) {
+            } else if (KeyUtils.isControlOrCommandDown(ke)) {
                 steps = steps * 10.0; //accelerate!
             }
             switch (ke.getKeyCode()) {

--- a/src/main/java/components/control/HRadioComponent.java
+++ b/src/main/java/components/control/HRadioComponent.java
@@ -18,6 +18,7 @@
 package components.control;
 
 import axoloti.Theme;
+import axoloti.utils.KeyUtils;
 import java.awt.BasicStroke;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -75,7 +76,7 @@ public class HRadioComponent extends ACtrlComponent {
 
     @Override
     public void keyPressed(KeyEvent ke) {
-        if (ke.isAltDown() || ke.isAltGraphDown() || ke.isControlDown() || ke.isMetaDown()) {
+        if (KeyUtils.isIgnoreModifierDown(ke)) {
             return;
         }
         switch (ke.getKeyCode()) {

--- a/src/main/java/components/control/NumberBoxComponent.java
+++ b/src/main/java/components/control/NumberBoxComponent.java
@@ -22,6 +22,7 @@ import axoloti.Theme;
 import axoloti.datatypes.ValueFrac32;
 import axoloti.realunits.NativeToReal;
 import axoloti.utils.Constants;
+import axoloti.utils.KeyUtils;
 import axoloti.utils.OSDetect;
 import java.awt.AWTException;
 import java.awt.BasicStroke;
@@ -108,7 +109,7 @@ public class NumberBoxComponent extends ACtrlComponent {
                 if (e.isShiftDown()) {
                     t = t * 0.1;
                 }
-                if (e.isControlDown()) {
+                if (KeyUtils.isControlOrCommandDown(e)) {
                     t = t * 0.1;
                 }
                 v = value + t * (MousePressedCoordY - e.getYOnScreen());
@@ -167,20 +168,16 @@ public class NumberBoxComponent extends ACtrlComponent {
         robot = null;
     }
 
-    private boolean isControlDown(KeyEvent ke) {
-        return OSDetect.getOS() == OSDetect.OS.MAC ? ke.isAltDown() : ke.isControlDown();
-    }
-
     @Override
     public void keyPressed(KeyEvent ke) {
         if (isEnabled()) {
             double steps = tick;
             if (ke.isShiftDown()) {
                 steps = steps * 0.1; // mini steps!
-                if (isControlDown(ke)) {
+                if (KeyUtils.isControlOrCommandDown(ke)) {
                     steps = steps * 0.1; // micro steps!                
                 }
-            } else if (isControlDown(ke)) {
+            } else if (KeyUtils.isControlOrCommandDown(ke)) {
                 steps = steps * 10.0; //accelerate!
             }
             switch (ke.getKeyCode()) {

--- a/src/main/java/components/control/VRadioComponent.java
+++ b/src/main/java/components/control/VRadioComponent.java
@@ -18,6 +18,7 @@
 package components.control;
 
 import axoloti.Theme;
+import axoloti.utils.KeyUtils;
 import java.awt.BasicStroke;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -75,7 +76,7 @@ public class VRadioComponent extends ACtrlComponent {
 
     @Override
     public void keyPressed(KeyEvent ke) {
-        if (ke.isAltDown() || ke.isAltGraphDown() || ke.isControlDown() || ke.isMetaDown()) {
+        if (KeyUtils.isIgnoreModifierDown(ke)) {
             return;
         }
         switch (ke.getKeyCode()) {


### PR DESCRIPTION
This patch replaces ALT with CTRL/CMD for our standard modifier. I also took the opportunity to clean up some of our key handling code so future changes like this are easier to make.