### PR TITLE
GUI: various repaint fixes

### DIFF
--- a/src/main/java/axoloti/Net.java
+++ b/src/main/java/axoloti/Net.java
@@ -108,7 +108,6 @@ public class Net extends JPanel {
         }
         source = source2;
         dest = dest2;
-        updateBounds();
     }
 
     public boolean isSelected() {
@@ -184,7 +183,7 @@ public class Net extends JPanel {
         g2.draw(curve);
     }
 
-    protected void updateBounds() {
+    public void updateBounds() {
         int min_y = Integer.MAX_VALUE;
         int min_x = Integer.MAX_VALUE;
         int max_y = Integer.MIN_VALUE;
@@ -214,6 +213,7 @@ public class Net extends JPanel {
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
+        updateBounds();
         float shadowOffset = 0.5f;
         Graphics2D g2 = (Graphics2D) g;
         g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
@@ -273,7 +273,6 @@ public class Net extends JPanel {
             DrawWire(g2, from.x, from.y, to.x, to.y);
 
         }
-        updateBounds();
     }
 
     public PatchGUI getPatchGui() {

--- a/src/main/java/axoloti/NetDragging.java
+++ b/src/main/java/axoloti/NetDragging.java
@@ -102,7 +102,7 @@ public class NetDragging extends Net {
     }
 
     @Override
-    protected void updateBounds() {
+    public void updateBounds() {
         int min_y = Integer.MAX_VALUE;
         int min_x = Integer.MAX_VALUE;
         int max_y = Integer.MIN_VALUE;

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -100,7 +100,7 @@ public class Patch {
         @ElementList(entry = "zombie", type = AxoObjectInstanceZombie.class, inline = true, required = false)})
     ArrayList<AxoObjectInstanceAbstract> objectinstances = new ArrayList<AxoObjectInstanceAbstract>();
     @ElementList(name = "nets")
-    ArrayList<Net> nets = new ArrayList<Net>();
+    public ArrayList<Net> nets = new ArrayList<Net>();
     @Element(required = false)
     PatchSettings settings;
     @Element(required = false, data = true)

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -909,6 +909,7 @@ public class PatchGUI extends Patch {
             if (isUpdate) {
                 AdjustSize();
                 SetDirty();
+                Layers.repaint();
             }
         } else {
             Logger.getLogger(PatchGUI.class.getName()).log(Level.INFO, "can't move: locked");
@@ -925,11 +926,17 @@ public class PatchGUI extends Patch {
         }
         for (Net n : nets) {
             netLayerPanel.add(n);
-            n.updateBounds();
         }
+        objectLayerPanel.validate();
+        netLayerPanel.validate();
+        
         Layers.setPreferredSize(new Dimension(5000, 5000));
         AdjustSize();
         Layers.revalidate();
+        
+        for (Net n : nets) {
+            n.updateBounds();
+        }
     }
 
     @Override

--- a/src/main/java/axoloti/displays/DisplayInstance1.java
+++ b/src/main/java/axoloti/displays/DisplayInstance1.java
@@ -17,6 +17,7 @@
  */
 package axoloti.displays;
 
+import axoloti.ZoomUtils;
 import axoloti.datatypes.Value;
 import java.nio.ByteBuffer;
 
@@ -45,7 +46,15 @@ public abstract class DisplayInstance1<T extends Display> extends DisplayInstanc
 
     @Override
     public void ProcessByteBuffer(ByteBuffer bb) {
-        getValueRef().setRaw(bb.getInt());
+        boolean shouldPaint = false;
+        int newValue = bb.getInt();
+        if(getValueRef().getInt() != newValue) {
+            shouldPaint = true;
+        }
+        getValueRef().setRaw(newValue);
         updateV();
+        if(shouldPaint) {
+            ZoomUtils.paintObjectLayer(this);
+        }
     }
 }

--- a/src/main/java/axoloti/iolet/IoletAbstract.java
+++ b/src/main/java/axoloti/iolet/IoletAbstract.java
@@ -130,6 +130,20 @@ public abstract class IoletAbstract extends JPanel {
         }
     }
 
+    private Point getJackLocInCanvasHidden() {
+        Point p1 = new Point(5, 5);
+        Component p = (Component) jack;
+        while (p != null) {
+            p1.x = p1.x + p.getX();
+            p1.y = p1.y + p.getY();
+            if (p == axoObj) {
+                break;
+            }
+            p = (Component) p.getParent();
+        }
+        return p1;
+    }
+
     public Point getJackLocInCanvas() {
         try {
             Point jackLocation = jack.getLocationOnScreen();
@@ -138,17 +152,10 @@ public abstract class IoletAbstract extends JPanel {
             SwingUtilities.convertPointFromScreen(jackLocation, getPatchGui().Layers);
             return jackLocation;
         } catch (IllegalComponentStateException e) {
-            Point p1 = new Point(5, 5);
-            Component p = (Component) jack;
-            while (p != null) {
-                p1.x = p1.x + p.getX();
-                p1.y = p1.y + p.getY();
-                if (p == axoObj) {
-                    break;
-                }
-                p = (Component) p.getParent();
-            }
-            return p1;
+            return getJackLocInCanvasHidden();
+        }
+        catch (NullPointerException e) {
+            return getJackLocInCanvasHidden();
         }
     }
 

--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -18,6 +18,7 @@
 package axoloti.object;
 
 import axoloti.MainFrame;
+import axoloti.Net;
 import axoloti.Patch;
 import axoloti.PatchGUI;
 import axoloti.SDFileReference;
@@ -394,8 +395,8 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     o.x = ((o.x + (Constants.X_GRID / 2)) / Constants.X_GRID) * Constants.X_GRID;
                     o.y = ((o.y + (Constants.Y_GRID / 2)) / Constants.Y_GRID) * Constants.Y_GRID;
                     o.setLocation(o.x, o.y);
-                    if(o.x != original_x || o.y != original_y) {
-                        setDirty = true;                        
+                    if (o.x != original_x || o.y != original_y) {
+                        setDirty = true;
                     }
                 }
                 if (setDirty) {
@@ -418,6 +419,9 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         this.y = y;
         if (patch != null) {
             patch.repaint();
+            for (Net n : patch.nets) {
+                n.updateBounds();
+            }
         }
     }
 
@@ -583,6 +587,12 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
         super.setLocation(x1, y1);
         x = x1;
         y = y1;
+        
+        if (patch != null) {
+            for (Net n : patch.nets) {
+                n.updateBounds();
+            }
+        }
     }
 
     public boolean providesModulationSource() {

--- a/src/main/java/axoloti/parameters/ParameterInstance.java
+++ b/src/main/java/axoloti/parameters/ParameterInstance.java
@@ -478,6 +478,10 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
                 midiAssign.setCC(-1);
             }
         }
+        if (midiAssign != null) {
+            midiAssign.repaint();
+            ZoomUtils.paintObjectLayer(axoObj);
+        }
     }
 
     public int getMidiCC() {

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
@@ -19,6 +19,7 @@ package axoloti.parameters;
 
 import axoloti.Preset;
 import axoloti.Theme;
+import axoloti.ZoomUtils;
 import axoloti.datatypes.Value;
 import components.AssignMidiCCComponent;
 import components.AssignMidiCCMenuItems;
@@ -60,6 +61,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public Preset AddPreset(int index, Value value) {
         Preset p = super.AddPreset(index, value);
         presetAssign.repaint();
+        ZoomUtils.paintObjectLayer(axoObj);
         return p;
     }
 
@@ -67,6 +69,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public void RemovePreset(int index) {
         super.RemovePreset(index);
         presetAssign.repaint();
+        ZoomUtils.paintObjectLayer(axoObj);
     }
 
     @Override
@@ -146,6 +149,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
         super.updateModulation(index, amount);
         if (modulationAssign != null) {
             modulationAssign.repaint();
+            ZoomUtils.paintObjectLayer(axoObj);
         }
     }
 

--- a/src/main/java/components/control/DialComponent.java
+++ b/src/main/java/components/control/DialComponent.java
@@ -226,6 +226,7 @@ public class DialComponent extends ACtrlComponent {
                     break;
                 default:
             }
+            repaint();
         }
     }
 


### PR DESCRIPTION
Fixes for:
- inaccurate net repaint on undo/redo
- some disp components not repainting in live mode
- not repainting objects properly after a midi cc / preset / modulation selection from the context menu
- dial components not repainting on keyboard change specifically at default zoom

I verified that repaints happen normally when a parameter is controlled from an external midi controller.