### PR TITLE
GUI: fix zoom and repaint strategy

### DIFF
--- a/src/main/java/axoloti/Net.java
+++ b/src/main/java/axoloti/Net.java
@@ -126,6 +126,9 @@ public class Net extends JPanel {
         for (InletInstance i : dest) {
             i.setHighlighted(selected);
         }
+        if (patch != null) {
+            this.repaint();
+        }
     }
 
     public boolean getSelected() {

--- a/src/main/java/axoloti/PatchGUI.java
+++ b/src/main/java/axoloti/PatchGUI.java
@@ -71,6 +71,7 @@ import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollBar;
 import javax.swing.KeyStroke;
+import javax.swing.RepaintManager;
 import javax.swing.TransferHandler;
 import javax.swing.plaf.LayerUI;
 import org.simpleframework.xml.Root;
@@ -270,7 +271,7 @@ public class PatchGUI extends Patch {
                         ShowClassSelector(p, null, null);
                     }
                 } else if (((ke.getKeyCode() == KeyEvent.VK_C) && !KeyUtils.isControlOrCommandDown(ke))
-                        || ((ke.getKeyCode() == KeyEvent.VK_5) &&  KeyUtils.isControlOrCommandDown(ke))) {
+                        || ((ke.getKeyCode() == KeyEvent.VK_5) && KeyUtils.isControlOrCommandDown(ke))) {
                     AxoObjectInstanceAbstract ao = AddObjectInstance(MainFrame.axoObjects.GetAxoObjectFromName(patchComment, null).get(0), Layers.getMousePosition());
                     ao.addInstanceNameEditor();
                     ke.consume();
@@ -492,7 +493,7 @@ public class PatchGUI extends Patch {
         };
 
         Layers.addMouseWheelListener(new MouseWheelListener() {
-            public void mouseWheelMoved(MouseWheelEvent e) {                
+            public void mouseWheelMoved(MouseWheelEvent e) {
                 if (KeyUtils.isControlOrCommandDown(e)) {
                     int notches = e.getWheelRotation();
                     Point origin = e.getPoint();
@@ -544,11 +545,15 @@ public class PatchGUI extends Patch {
         Layers.setVisible(true);
         Layers.setLocation(0, 0);
         Layers.setPreferredSize(LayersSize);
+
+        RepaintManager.setCurrentManager(new ZoomRepaintManager(zoomUI));
     }
 
     public void handlePan(MouseEvent ev) {
-        if(panOrigin == null) return;
-        
+        if (panOrigin == null) {
+            return;
+        }
+
         int dx = panOrigin.x - ev.getX();
         int dy = panOrigin.y - ev.getY();
         JScrollBar horizontal = PatchGUI.this.getPatchframe().getScrollPane().getHorizontalScrollBar();
@@ -927,11 +932,11 @@ public class PatchGUI extends Patch {
         }
         objectLayerPanel.validate();
         netLayerPanel.validate();
-        
+
         Layers.setPreferredSize(new Dimension(5000, 5000));
         AdjustSize();
         Layers.revalidate();
-        
+
         for (Net n : nets) {
             n.updateBounds();
         }
@@ -1212,11 +1217,11 @@ public class PatchGUI extends Patch {
             settings.editor.dispose();
         }
     }
-    
+
     void cleanUpObjectLayer() {
         if (!IsLocked()) {
-            for(Component c : this.objectLayerPanel.getComponents()) {
-                if(!objectinstances.contains(c)) {
+            for (Component c : this.objectLayerPanel.getComponents()) {
+                if (!objectinstances.contains(c)) {
                     this.objectLayerPanel.remove(c);
                 }
             }

--- a/src/main/java/axoloti/ZoomRepaintManager.java
+++ b/src/main/java/axoloti/ZoomRepaintManager.java
@@ -1,0 +1,29 @@
+package axoloti;
+
+import java.awt.Rectangle;
+import javax.swing.JComponent;
+import javax.swing.JLayer;
+import javax.swing.RepaintManager;
+import javax.swing.SwingUtilities;
+
+public class ZoomRepaintManager extends RepaintManager {
+
+    private ZoomUI zoomUI;
+
+    ZoomRepaintManager(ZoomUI zoomUI) {
+        this.zoomUI = zoomUI;
+    }
+
+    @Override
+    public void addDirtyRegion(JComponent c, int x, int y, int w, int h) {
+        JLayer layer = ZoomUtils.getAncestorLayer(c);
+        if (layer != null) {
+            Rectangle bounds = c.getBounds();
+            bounds = SwingUtilities.convertRectangle(c.getParent(), bounds, layer);
+            zoomUI.scale(bounds);
+
+            super.addDirtyRegion(layer, bounds.x, bounds.y, bounds.width, bounds.height);
+        }
+        super.addDirtyRegion(c, x, y, w, h);
+    }
+}

--- a/src/main/java/axoloti/ZoomUI.java
+++ b/src/main/java/axoloti/ZoomUI.java
@@ -252,19 +252,12 @@ public class ZoomUI extends LayerUI<JComponent> {
     }
 
     @Override
-    protected void processFocusEvent(FocusEvent e,
-            JLayer<? extends JComponent> l) {
-        patch.Layers.repaint();
-    }
-
-    @Override
     public void installUI(JComponent c) {
         super.installUI(c);
         JLayer<? extends JComponent> jlayer = (JLayer<? extends JComponent>) c;
         jlayer.setLayerEventMask(AWTEvent.MOUSE_EVENT_MASK
                 | AWTEvent.MOUSE_MOTION_EVENT_MASK
-                | AWTEvent.KEY_EVENT_MASK
-                | AWTEvent.FOCUS_EVENT_MASK);
+                | AWTEvent.KEY_EVENT_MASK);
     }
 
     @Override

--- a/src/main/java/axoloti/ZoomUtils.java
+++ b/src/main/java/axoloti/ZoomUtils.java
@@ -5,7 +5,6 @@ import axoloti.utils.Constants;
 import axoloti.utils.LRUCache;
 import java.awt.Component;
 import java.awt.Point;
-import java.awt.Rectangle;
 import java.awt.event.MouseEvent;
 import javax.swing.JLayer;
 import javax.swing.JPopupMenu;
@@ -48,48 +47,12 @@ public class ZoomUtils {
 
     private static final LRUCache<Component, JLayer> ANCESTOR_CACHE = new LRUCache<Component, JLayer>(Constants.ANCESTOR_CACHE_SIZE);
 
-    private static JLayer getAncestorLayer(Component c) {
+    public static JLayer getAncestorLayer(Component c) {
         JLayer ancestor = ANCESTOR_CACHE.get(c);
         if (ancestor == null) {
             ancestor = (JLayer) SwingUtilities.getAncestorOfClass(JLayer.class, c);
             ANCESTOR_CACHE.put(c, ancestor);
         }
         return ancestor;
-    }
-
-    public static void paintObjectLayer(Component component) {
-        JLayer layer = getAncestorLayer(component);
-        if (layer != null) {
-            ZoomUI zoomUI = ((ZoomUI) layer.getUI());
-            paintObjectLayer(layer, component, zoomUI);
-        }
-    }
-
-    public static void paintObjectLayer(JLayer layer, Component component, ZoomUI zoomUI) {
-        paintObjectLayer(layer, component, zoomUI, true);
-    }
-    
-    public static void paintObjectLayer(JLayer layer, Component component, ZoomUI zoomUI, boolean convert) {
-        if(layer == null) {
-            layer = getAncestorLayer(component);
-        }
-        
-        if (layer != null) {
-            Rectangle bounds = component.getBounds();
-            if(convert) {
-                bounds = SwingUtilities.convertRectangle(component.getParent(), bounds, layer);
-                layer.repaint(bounds.x,
-                        bounds.y,
-                        bounds.width,
-                        bounds.height);
-            }
-            
-            zoomUI.scale(bounds);
-            
-            layer.repaint(bounds.x,
-                    bounds.y,
-                    bounds.width,
-                    bounds.height);
-        }
     }
 }

--- a/src/main/java/axoloti/attribute/AttributeInstanceObjRef.java
+++ b/src/main/java/axoloti/attribute/AttributeInstanceObjRef.java
@@ -77,7 +77,7 @@ public class AttributeInstanceObjRef extends AttributeInstanceString<AxoAttribut
 
             @Override
             public void keyPressed(KeyEvent ke) {
-                axoObj.getParent().repaint();
+                repaint();
             }
         });
         TFObjName.addActionListener(new ActionListener() {

--- a/src/main/java/axoloti/attribute/AttributeInstanceSDFile.java
+++ b/src/main/java/axoloti/attribute/AttributeInstanceSDFile.java
@@ -85,7 +85,7 @@ public class AttributeInstanceSDFile extends AttributeInstanceString<AxoAttribut
 
             @Override
             public void keyPressed(KeyEvent ke) {
-                axoObj.getParent().repaint();
+                repaint();
             }
         });
         TFFileName.addActionListener(new ActionListener() {

--- a/src/main/java/axoloti/attribute/AttributeInstanceTablename.java
+++ b/src/main/java/axoloti/attribute/AttributeInstanceTablename.java
@@ -76,7 +76,7 @@ public class AttributeInstanceTablename extends AttributeInstanceString<AxoAttri
 
             @Override
             public void keyPressed(KeyEvent ke) {
-                axoObj.getParent().repaint();
+                repaint();
             }
         });
         TFtableName.addActionListener(new ActionListener() {

--- a/src/main/java/axoloti/attribute/AttributeInstanceWavefile.java
+++ b/src/main/java/axoloti/attribute/AttributeInstanceWavefile.java
@@ -84,7 +84,7 @@ public class AttributeInstanceWavefile extends AttributeInstance<AxoAttributeWav
 
             @Override
             public void keyPressed(KeyEvent ke) {
-                axoObj.getParent().repaint();
+                repaint();
             }
         });
         TFwaveFilename.addActionListener(new ActionListener() {

--- a/src/main/java/axoloti/displays/DisplayInstance1.java
+++ b/src/main/java/axoloti/displays/DisplayInstance1.java
@@ -17,7 +17,6 @@
  */
 package axoloti.displays;
 
-import axoloti.ZoomUtils;
 import axoloti.datatypes.Value;
 import java.nio.ByteBuffer;
 
@@ -46,15 +45,7 @@ public abstract class DisplayInstance1<T extends Display> extends DisplayInstanc
 
     @Override
     public void ProcessByteBuffer(ByteBuffer bb) {
-        boolean shouldPaint = false;
-        int newValue = bb.getInt();
-        if(getValueRef().getInt() != newValue) {
-            shouldPaint = true;
-        }
-        getValueRef().setRaw(newValue);
+        getValueRef().setRaw(bb.getInt());
         updateV();
-        if(shouldPaint) {
-            ZoomUtils.paintObjectLayer(this);
-        }
     }
 }

--- a/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceAbstract.java
@@ -162,6 +162,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             if ((o1 != null) && (o1 != this)) {
                 Logger.getLogger(AxoObjectInstanceAbstract.class.getName()).log(Level.SEVERE, "Object name {0} already exists!", InstanceName);
                 doLayout();
+                repaint();
                 return;
             }
         }
@@ -170,6 +171,9 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             InstanceLabel.setText(InstanceName);
         }
         doLayout();
+        if (getParent() != null) {
+            getParent().repaint();
+        }
     }
 
     public AxoObjectAbstract getType() {
@@ -241,9 +245,11 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     if (me.getClickCount() == 1) {
                         if (me.isShiftDown()) {
                             SetSelected(!GetSelected());
+                            ((PatchGUI) patch).repaint();
                         } else if (Selected == false) {
                             ((PatchGUI) patch).SelectNone();
                             SetSelected(true);
+                            ((PatchGUI) patch).repaint();
                         }
                     }
                     if (me.getClickCount() == 2) {
@@ -452,6 +458,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                 String s = InstanceNameTF.getText();
                 setInstanceName(s);
                 getParent().remove(InstanceNameTF);
+                patch.repaint();
             }
 
             @Override
@@ -473,6 +480,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
                     String s = InstanceNameTF.getText();
                     setInstanceName(s);
                     getParent().remove(InstanceNameTF);
+                    repaint();
                 }
             }
         });
@@ -563,6 +571,7 @@ public abstract class AxoObjectInstanceAbstract extends JPanel implements Compar
             } else {
                 setBorder(BorderFactory.createLineBorder(Theme.getCurrentTheme().Object_Border_Unselected));
             }
+            repaint();
         }
         this.Selected = Selected;
     }

--- a/src/main/java/axoloti/object/AxoObjectInstanceComment.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceComment.java
@@ -138,6 +138,7 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
                 String s = InstanceNameTF.getText();
                 setInstanceName(s);
                 getParent().remove(InstanceNameTF);
+                getParent().repaint();
             }
 
             @Override
@@ -159,6 +160,7 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
                     String s = InstanceNameTF.getText();
                     setInstanceName(s);
                     getParent().remove(InstanceNameTF);
+                    getParent().repaint();
                 }
             }
         });
@@ -176,6 +178,9 @@ public class AxoObjectInstanceComment extends AxoObjectInstanceAbstract {
             InstanceLabel.setText(commentText);
         }
         doLayout();
+        if (getParent() != null) {
+            getParent().repaint();
+        }
         resizeToGrid();
     }
 

--- a/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
+++ b/src/main/java/axoloti/object/AxoObjectInstanceZombie.java
@@ -135,6 +135,7 @@ public class AxoObjectInstanceZombie extends AxoObjectInstanceAbstract {
     public void setInstanceName(String s) {
         super.setInstanceName(s);
         resizeToGrid();
+        repaint();
     }
 
     @Override

--- a/src/main/java/axoloti/parameters/ParameterInstance.java
+++ b/src/main/java/axoloti/parameters/ParameterInstance.java
@@ -478,10 +478,6 @@ public abstract class ParameterInstance<T extends Parameter> extends JPanel impl
                 midiAssign.setCC(-1);
             }
         }
-        if (midiAssign != null) {
-            midiAssign.repaint();
-            ZoomUtils.paintObjectLayer(axoObj);
-        }
     }
 
     public int getMidiCC() {

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
@@ -19,7 +19,6 @@ package axoloti.parameters;
 
 import axoloti.Preset;
 import axoloti.Theme;
-import axoloti.ZoomUtils;
 import axoloti.datatypes.Value;
 import components.AssignMidiCCComponent;
 import components.AssignMidiCCMenuItems;
@@ -61,7 +60,6 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public Preset AddPreset(int index, Value value) {
         Preset p = super.AddPreset(index, value);
         presetAssign.repaint();
-        ZoomUtils.paintObjectLayer(axoObj);
         return p;
     }
 
@@ -69,7 +67,6 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public void RemovePreset(int index) {
         super.RemovePreset(index);
         presetAssign.repaint();
-        ZoomUtils.paintObjectLayer(axoObj);
     }
 
     @Override
@@ -149,7 +146,6 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
         super.updateModulation(index, amount);
         if (modulationAssign != null) {
             modulationAssign.repaint();
-            ZoomUtils.paintObjectLayer(axoObj);
         }
     }
 

--- a/src/main/java/components/DropDownComponent.java
+++ b/src/main/java/components/DropDownComponent.java
@@ -115,6 +115,7 @@ public class DropDownComponent extends JComponent implements MouseListener {
             for (DDCListener il : ddcListeners) {
                 il.SelectionChanged();
             }
+            repaint();
         }
     }
     

--- a/src/main/java/components/VGraphComponent.java
+++ b/src/main/java/components/VGraphComponent.java
@@ -18,7 +18,6 @@
 package components;
 
 import axoloti.Theme;
-import axoloti.ZoomUtils;
 import java.awt.BasicStroke;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -101,7 +100,7 @@ public class VGraphComponent extends JComponent {
         for (int i = 0; i < length; i++) {
             this.ypoints[i] = valToPos(value[i]);
         }
-        ZoomUtils.paintObjectLayer(this);
+        repaint();
     }
 
     public double getMinimum() {

--- a/src/main/java/components/control/ACtrlComponent.java
+++ b/src/main/java/components/control/ACtrlComponent.java
@@ -29,6 +29,8 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
@@ -55,6 +57,17 @@ public abstract class ACtrlComponent extends JComponent {
 
     public ACtrlComponent() {
         setFocusable(true);
+        addFocusListener(new FocusListener() {
+            @Override
+            public void focusGained(FocusEvent fe) {
+                repaint();
+            }
+
+            @Override
+            public void focusLost(FocusEvent fe) {
+                repaint();
+            }
+        });
         addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {

--- a/src/main/java/components/control/Checkbox4StatesComponent.java
+++ b/src/main/java/components/control/Checkbox4StatesComponent.java
@@ -105,6 +105,7 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
                 if (selIndex < 0) {
                     selIndex = n - 1;
                 }
+                repaint();
                 ke.consume();
                 return;
             }
@@ -113,6 +114,7 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
                 if (selIndex >= n) {
                     selIndex = 0;
                 }
+                repaint();
                 ke.consume();
                 return;
             }
@@ -245,8 +247,8 @@ public class Checkbox4StatesComponent extends ACtrlComponent {
     public void setValue(double value) {
         if (this.value != value) {
             this.value = value;
+            repaint();
         }
-        repaint();
         fireEvent();
     }
 

--- a/src/main/java/components/control/CheckboxComponent.java
+++ b/src/main/java/components/control/CheckboxComponent.java
@@ -76,6 +76,7 @@ public class CheckboxComponent extends ACtrlComponent {
             if (i < n) {
                 SetFieldValue(i, dragValue);
                 selIndex = i;
+                repaint();
             }
         }
     }
@@ -114,6 +115,7 @@ public class CheckboxComponent extends ACtrlComponent {
                 if (selIndex < 0) {
                     selIndex = n - 1;
                 }
+                repaint();
                 ke.consume();
                 return;
             }
@@ -122,6 +124,7 @@ public class CheckboxComponent extends ACtrlComponent {
                 if (selIndex >= n) {
                     selIndex = 0;
                 }
+                repaint();
                 ke.consume();
                 return;
             }
@@ -225,8 +228,8 @@ public class CheckboxComponent extends ACtrlComponent {
     public void setValue(double value) {
         if (this.value != value) {
             this.value = value;
+            repaint();
         }
-        repaint();
         fireEvent();
     }
 

--- a/src/main/java/components/control/DialComponent.java
+++ b/src/main/java/components/control/DialComponent.java
@@ -198,16 +198,19 @@ public class DialComponent extends ACtrlComponent {
                     }
                     keybBuffer = "";
                     ke.consume();
+                    repaint();
                     break;
                 case KeyEvent.VK_BACK_SPACE:
                     if (keybBuffer.length() > 0) {
                         keybBuffer = keybBuffer.substring(0, keybBuffer.length() - 1);
                     }
                     ke.consume();
+                    repaint();
                     break;
                 case KeyEvent.VK_ESCAPE:
                     keybBuffer = "";
                     ke.consume();
+                    repaint();
                     break;
                 default:
             }

--- a/src/main/java/components/control/NumberBoxComponent.java
+++ b/src/main/java/components/control/NumberBoxComponent.java
@@ -159,9 +159,11 @@ public class NumberBoxComponent extends ACtrlComponent {
     protected void mouseReleased(MouseEvent e) {
         if (hiliteDown) {
             hiliteDown = false;
+            repaint();
         }
         if (hiliteUp) {
             hiliteUp = false;
+            repaint();            
         }
         getRootPane().setCursor(Cursor.getDefaultCursor());
         robot = null;
@@ -213,16 +215,19 @@ public class NumberBoxComponent extends ACtrlComponent {
                     }
                     keybBuffer = "";
                     ke.consume();
+                    repaint();
                     break;
                 case KeyEvent.VK_BACK_SPACE:
                     if (keybBuffer.length() > 0) {
                         keybBuffer = keybBuffer.substring(0, keybBuffer.length() - 1);
                     }
                     ke.consume();
+                    repaint();
                     break;
                 case KeyEvent.VK_ESCAPE:
                     keybBuffer = "";
                     ke.consume();
+                    repaint();
                     break;
                 default:
             }
@@ -241,6 +246,7 @@ public class NumberBoxComponent extends ACtrlComponent {
                 case '.':
                     keybBuffer += ke.getKeyChar();
                     ke.consume();
+                    repaint();
                     break;
                 default:
             }

--- a/src/main/java/components/control/VSliderComponent.java
+++ b/src/main/java/components/control/VSliderComponent.java
@@ -146,16 +146,19 @@ public class VSliderComponent extends ACtrlComponent {
                 }
                 keybBuffer = "";
                 ke.consume();
+                repaint();
                 break;
             case KeyEvent.VK_BACK_SPACE:
                 if (keybBuffer.length() > 0) {
                     keybBuffer = keybBuffer.substring(0, keybBuffer.length() - 1);
                 }
                 ke.consume();
+                repaint();
                 break;
             case KeyEvent.VK_ESCAPE:
                 keybBuffer = "";
                 ke.consume();
+                repaint();
                 break;
             default:
         }
@@ -174,6 +177,7 @@ public class VSliderComponent extends ACtrlComponent {
             case '.':
                 keybBuffer += ke.getKeyChar();
                 ke.consume();
+                repaint();
                 break;
             default:
         }


### PR DESCRIPTION
The fundamental problem with our current zooming approach is that the components themselves are unaware of the fact that they're in a layer context that might apply a scale factor. So a call to repaint() from inside a component results in the unscaled region being repainted, not the entire zoomed region in the containing layer.

This patch uses a custom RepaintManager in such a way that standard repaints end up setting the appropriate zoomed region as dirty and swing takes care of the rest. Painting is completely removed from ZoomUI aside from the one place where we perform the scaling of a layer. We also return to our repaint strategy from before zoom was originally merged where each component is responsible for calling repaint in the appropriate place.