### PR TITLE
Update codec_ADAU1961_SAI.c

### DIFF
--- a/firmware/codec_ADAU1961_SAI.c
+++ b/firmware/codec_ADAU1961_SAI.c
@@ -443,7 +443,6 @@ void codec_ADAU1961_i2s_init(uint16_t sampleRate) {
   SAI1_Block_A->CR1 |= SAI_xCR1_SAIEN;
   SAI1_Block_B->CR1 |= SAI_xCR1_SAIEN;
 
-  codec_ADAU1961_hw_init(sampleRate);
 }
 
 void codec_ADAU1961_Stop(void) {


### PR DESCRIPTION
removed redundant codec_ADAU1961_hw_init() call, as it is carried out in codec.c by codec_init()