### PR TITLE
GUI: fix preset clear null pointer exception

### DIFF
--- a/src/main/java/components/AssignPresetMenuItems.java
+++ b/src/main/java/components/AssignPresetMenuItems.java
@@ -63,7 +63,9 @@ public class AssignPresetMenuItems {
             mi.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    AssignPresetMenuItems.this.param.getPresets().clear();
+                    if (AssignPresetMenuItems.this.param.getPresets() != null) {
+                        AssignPresetMenuItems.this.param.getPresets().clear();
+                    }
                 }
             });
             parent.add(mi);


### PR DESCRIPTION
Noticed this bug in master when developing something on one of my feature branches.

Current behavior:
- Select "Clear all presets" from the preset assign menu without first "Including in current preset" -> NPE
or
- Include and then exclude a parameter, then clear all. -> NPE

It's annoying to check for and then reassign null when dealing with fields that may be persisted. It would be nice to come up with a better strategy for default values for these fields. Going to give that some thought, but for now here's the easy fix.