### PR TITLE
Keyed-in unit interpretation

### DIFF
--- a/src/main/java/axoloti/Net.java
+++ b/src/main/java/axoloti/Net.java
@@ -329,6 +329,10 @@ public class Net extends JComponent {
         DataType t = source.get(0).GetDataType();
         return t;
     }
+    
+    public ArrayList<OutletInstance> GetSource() {
+        return source;
+    }
 
     public String CType() {
         DataType d = GetDataType();

--- a/src/main/java/axoloti/Patch.java
+++ b/src/main/java/axoloti/Patch.java
@@ -62,6 +62,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -875,6 +876,66 @@ public class Patch {
         Collections.sort(this.objectinstances);
         refreshIndexes();
     }
+    
+    void SortParentsByExecution(AxoObjectInstanceAbstract o, LinkedList<AxoObjectInstanceAbstract> result)
+    {
+        LinkedList<AxoObjectInstanceAbstract> before = new LinkedList<AxoObjectInstanceAbstract>(result);
+        LinkedList<AxoObjectInstanceAbstract> parents = new LinkedList<AxoObjectInstanceAbstract>();
+        // get the parents
+        for (InletInstance il : o.GetInletInstances()) {
+            Net n = GetNet(il);
+            if (n != null) {
+                for (OutletInstance ol: n.GetSource()) {
+                    AxoObjectInstanceAbstract i = ol.GetObjectInstance();
+                    if (!parents.contains(i)) {    
+                        parents.add(i);
+                    }
+                }
+            }
+        }
+        // sort the parents
+        Collections.sort(parents);
+        // prepend any we haven't seen before
+        for (AxoObjectInstanceAbstract c: parents) {
+            if (!result.contains(c))
+                result.addFirst(c);
+        }
+        // prepend their parents 
+        for (AxoObjectInstanceAbstract c: parents) {
+            if (!before.contains(c))
+                SortParentsByExecution(c, result);
+        }
+    }
+
+    void SortByExecution() {
+        LinkedList<AxoObjectInstanceAbstract> endpoints = new LinkedList<AxoObjectInstanceAbstract>();
+        LinkedList<AxoObjectInstanceAbstract> result = new LinkedList<AxoObjectInstanceAbstract>();
+        // start with all objects without outlets (end points)
+        for (AxoObjectInstanceAbstract o : objectinstances) {
+            if (o.GetOutletInstances().isEmpty()) {
+                endpoints.add(o);
+            } else {
+                int count = 0;
+                for (OutletInstance ol : o.GetOutletInstances()) {
+                    if (GetNet(ol) != null)
+                        count++;
+                }
+                if (count == 0)
+                    endpoints.add(o);
+            }
+        }
+        // sort them by position
+        Collections.sort(endpoints);
+        // walk their inlets
+        for (AxoObjectInstanceAbstract o : endpoints) {
+            SortParentsByExecution(o, result);
+        }
+        // add the end points
+        result.addAll(endpoints);
+        // turn it back into a freshly sorted array
+        objectinstances = new ArrayList<AxoObjectInstanceAbstract>(result);
+        refreshIndexes();
+    }
 
     public Modulator GetModulatorOfModulation(Modulation modulation) {
         if (Modulators == null) {
@@ -1541,7 +1602,7 @@ public class Patch {
         }
 
         CreateIID();
-        SortByPosition();
+        SortByExecution();
         String c = generateIncludes();
         c += "\n"
                 + "#pragma GCC diagnostic ignored \"-Wunused-variable\"\n"

--- a/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
+++ b/src/main/java/axoloti/parameters/ParameterInstanceFrac32UMap.java
@@ -53,6 +53,7 @@ public class ParameterInstanceFrac32UMap<T extends ParameterFrac32> extends Para
     public DialComponent CreateControl() {
         DialComponent d = new DialComponent(0.0, getMin(), getMax(), getTick());
         d.setParentAxoObjectInstance(axoObj);
+        d.setNative(convs);
         return d;
     }
 

--- a/src/main/java/axoloti/realunits/DecayTime.java
+++ b/src/main/java/axoloti/realunits/DecayTime.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -38,5 +41,30 @@ public class DecayTime implements NativeToReal {
         } else {
             return (String.format("%.1f ms", t * 1000));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[mM]?)[sS]");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not DecayTime", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+
+            double t = num * mul;
+            return -(((Math.log(2.0)  * (16 / 48000.0) * 4096) / t) - 64);
+        }
+
+        throw new ParseException("Not DecayTime", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/DecayTimeReverse.java
+++ b/src/main/java/axoloti/realunits/DecayTimeReverse.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -35,5 +38,30 @@ public class DecayTimeReverse implements NativeToReal {
         } else {
             return (String.format("%.1f ms", t * 1000));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[mM]?)[sS]");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not DecayTimeReverse", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+
+            double t = num * mul;
+            return 1 / (t / Math.log(2.0) * (16 / 48000.0) * 4096);
+        }
+
+        throw new ParseException("Not DecayTimeReverse", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/FilterQ.java
+++ b/src/main/java/axoloti/realunits/FilterQ.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -29,5 +32,31 @@ public class FilterQ implements NativeToReal {
     public String ToReal(Value v) {
         double q = 32 / (64 - v.getDouble());
         return (String.format("Q=%.1f", q));
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<unit1>[qQ]?)(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit2>[qQ]?)");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not DecayTime", 0);
+            }
+
+            String units1 = matcher.group("unit1");
+            String units2 = matcher.group("unit2");
+            if (!(units1.contains("q") || units1.contains("Q") || units2.contains("q") || units2.contains("Q")))
+                throw new ParseException("Not FilterQ", 0);
+
+            double q = num;
+            return -((32 / q) - 64);
+        }
+
+        throw new ParseException("Not FilterQ", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/FreqHz.java
+++ b/src/main/java/axoloti/realunits/FreqHz.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -38,5 +41,32 @@ public class FreqHz implements NativeToReal {
         } else {
             return (String.format("%.2f Hz", hz));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[kKmM]?)[hH][zZ]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not FreqHz", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+            if (units.contains("k") || units.contains("K"))
+                mul = 1000;
+
+            double hz = num * mul;
+            return (hz * 64.0) / (48000.0 * 0.5);
+        }
+
+        throw new ParseException("Not FreqHz", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/KPitchHz.java
+++ b/src/main/java/axoloti/realunits/KPitchHz.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -41,5 +44,32 @@ public class KPitchHz implements NativeToReal {
         } else {
             return (String.format("%.3f Hz", hz));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[kKmM]?)[hH][zZ]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not KPitchHz", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+            if (units.contains("k") || units.contains("K"))
+                mul = 1000;
+
+            double hz = num * mul;
+            return ((Math.log((hz * 16.0) / 440.0) / Math.log(2)) * 12.0) - 64 + 69;
+        }
+
+        throw new ParseException("Not KPitchHz", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/LFOBPM.java
+++ b/src/main/java/axoloti/realunits/LFOBPM.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -36,5 +39,26 @@ public class LFOBPM implements NativeToReal {
         } else {
             return (String.format("%.1f/min", bpm));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*/[mM]?[iI]?[nN]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LFOBPM", 0);
+            }
+
+            double hz = num / 60.0;
+            return ((Math.log((hz * 64) / 440.0) / Math.log(2)) * 12.0) - 64 + 69;
+        }
+
+        throw new ParseException("Not LFOBPM", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/LFOPeriod.java
+++ b/src/main/java/axoloti/realunits/LFOPeriod.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -38,4 +41,29 @@ public class LFOPeriod implements NativeToReal {
         }
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[mM]?)[sS]");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LFOPeriod", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M")) {
+                mul = 0.001;
+            }
+
+            double hz = 1.0 / (num * mul);
+            return ((Math.log((hz * 64) / 440.0) / Math.log(2)) * 12.0) - 64 + 69;
+        }
+
+        throw new ParseException("Not LFOPeriod", 0);
+    }
 }

--- a/src/main/java/axoloti/realunits/LFOPitchHz.java
+++ b/src/main/java/axoloti/realunits/LFOPitchHz.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -37,4 +40,30 @@ public class LFOPitchHz implements NativeToReal {
         }
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[kKmM]?)[hH][zZ]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LFOPitchHz", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+            if (units.contains("k") || units.contains("K"))
+                mul = 1000;
+
+            double hz = num * mul;
+            return ((Math.log((hz * 64) / 440.0) / Math.log(2)) * 12.0) - 64 + 69;
+        }
+
+        throw new ParseException("Not LFOPitchHz", 0);
+    }
 }

--- a/src/main/java/axoloti/realunits/LFORatio.java
+++ b/src/main/java/axoloti/realunits/LFORatio.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -30,4 +33,28 @@ public class LFORatio implements NativeToReal {
         return (String.format("x%.3f", Math.pow(2.0, (v.getDouble()) / 12.0)));
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<unit1>[xX\\*]?)\\p{Space}*(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit2>[xX\\*]?)");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LFORatio", 0);
+            }
+
+            String units1 = matcher.group("unit1");
+            String units2 = matcher.group("unit2");
+            if (!(units1.contains("x") || units1.contains("X") || units1.contains("*") || units2.contains("x") || units2.contains("X") || units2.contains("*")))
+                throw new ParseException("Not LFORatio", 0);
+
+            return (Math.log(num) / Math.log(2)) * 12.0;
+        }
+
+        throw new ParseException("Not LFORatio", 0);
+    }
 }

--- a/src/main/java/axoloti/realunits/LinDB.java
+++ b/src/main/java/axoloti/realunits/LinDB.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -38,5 +41,25 @@ public class LinDB implements NativeToReal {
         } else {
             return "-infdB";
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*[dD][bB]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LinDB", 0);
+            }
+
+            return Math.pow(10.0, (num - maxGain) / 20) * 64.0;
+        }
+
+        throw new ParseException("Not LinDB", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/LinRatio.java
+++ b/src/main/java/axoloti/realunits/LinRatio.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -36,4 +39,28 @@ public class LinRatio implements NativeToReal {
         return (String.format("x%.3f", range * v.getDouble() / 64.0));
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<unit1>[xX\\*]?)\\p{Space}*(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit2>[xX\\*]?)");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LinRatio", 0);
+            }
+
+            String units1 = matcher.group("unit1");
+            String units2 = matcher.group("unit2");
+            if (!(units1.contains("x") || units1.contains("X") || units1.contains("*") || units2.contains("x") || units2.contains("X") || units2.contains("*")))
+                throw new ParseException("Not LinRatio", 0);
+
+            return (num * 64) / range;
+        }
+
+        throw new ParseException("Not LinRatio", 0);
+    }
 }

--- a/src/main/java/axoloti/realunits/LinearTimeExp.java
+++ b/src/main/java/axoloti/realunits/LinearTimeExp.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -36,5 +39,30 @@ public class LinearTimeExp implements NativeToReal {
         } else {
             return (String.format("%.2f ms", t * 1000));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[mM]?)[sS]");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LinearTimeExp", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+
+            double hz = 1.0 / (num * mul);
+            return -(((Math.log((hz * 32) / 440.0) / Math.log(2)) * 12.0) - 64 + 69);
+        }
+
+        throw new ParseException("Not LinearTimeExp", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/LinearTimeReverse.java
+++ b/src/main/java/axoloti/realunits/LinearTimeReverse.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -35,5 +38,30 @@ public class LinearTimeReverse implements NativeToReal {
         } else {
             return (String.format("%.1f ms", t * 1000));
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[mM]?)[sS]");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not LinearTimeReverse", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+
+            double t = num * mul;
+            return 1.0 / (t / ((16 / 48000.0) * 8192));
+        }
+
+        throw new ParseException("Not LinearTimeReverse", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/NativeToReal.java
+++ b/src/main/java/axoloti/realunits/NativeToReal.java
@@ -18,6 +18,7 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.text.ParseException;
 
 /**
  *
@@ -26,4 +27,5 @@ import axoloti.datatypes.Value;
 public interface NativeToReal {
 
     String ToReal(Value v);
+    double FromReal(String s) throws ParseException;
 }

--- a/src/main/java/axoloti/realunits/PitchHz.java
+++ b/src/main/java/axoloti/realunits/PitchHz.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -42,4 +45,29 @@ public class PitchHz implements NativeToReal {
         }
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit>[kKmM]?)[hH][zZ]?");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.matches()) {
+            double num, mul = 1.0;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not PitchHz", 0);
+            }
+
+            String units = matcher.group("unit");
+            if (units.contains("m") || units.contains("M"))
+                mul = 0.001;
+            if (units.contains("k") || units.contains("K"))
+                mul = 1000;
+
+            double hz = num * mul;
+            return ((Math.log(hz / 440.0) / Math.log(2)) * 12.0) - 64 + 69;
+        }
+
+        throw new ParseException("Not PitchHz", 0);
+    }
 }

--- a/src/main/java/axoloti/realunits/PitchToNote.java
+++ b/src/main/java/axoloti/realunits/PitchToNote.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -82,6 +85,82 @@ public class PitchToNote implements NativeToReal {
             s += "   ";
         }
         return s;
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<note>[a-gA-G])\\p{Space}*(?<sharp>[#bB]?)\\p{Space}*(?<oct>\\d+)\\p{Space}*(?<sign>[-\\+]?)\\p{Space}*(?<delta>\\d*)");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double n;
+            char note, sharp = 0, sign = 0;
+            int incidental = 0, oct, delta = 0;
+
+            note = matcher.group("note").toLowerCase().charAt(0);
+            if (matcher.group("sharp").length() != 0)
+                sharp = matcher.group("sharp").toLowerCase().charAt(0);
+            if (matcher.group("sign").length() != 0)
+                sign = matcher.group("sign").toLowerCase().charAt(0);
+            try {
+                oct = Integer.parseInt(matcher.group("oct"));
+                if (matcher.group("delta").length() != 0)
+                    delta = Integer.parseInt(matcher.group("delta"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not PitchToNote", 0);
+            }
+
+            if (sharp == '#')
+            {
+                incidental = 1;
+            }
+            else if (sharp == 'b')
+            {
+                if (note == 'a')
+                    note = 'g';
+                else
+                    note--;
+                incidental = 1;
+            }
+
+            switch (note) {
+                case 'a':
+                    n = 9 + incidental;
+                    break;
+                case 'b':
+                    n = 11;
+                    break;
+                case 'c':
+                    n = 0 + incidental;
+                    break;
+                case 'd':
+                    n = 2 + incidental;
+                    break;
+                case 'e':
+                    n = 4;
+                    break;
+                case 'f':
+                    n = 5 + incidental;
+                    break;
+                case 'g':
+                    n = 7 + incidental;
+                    break;
+                default:
+                    throw new ParseException("Not PitchToNote", 0);
+            }
+            n += (oct * 12) - 52;
+            if (sign == '+')
+            {
+                n += delta / 100.0;
+            }
+            else if (sign == '-')
+            {
+                n -= delta / 100.0;
+            }
+            return n;
+        }
+
+        throw new ParseException("Not PitchToNote", 0);
     }
 
 }

--- a/src/main/java/axoloti/realunits/PitchToRatio.java
+++ b/src/main/java/axoloti/realunits/PitchToRatio.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -28,5 +31,29 @@ public class PitchToRatio implements NativeToReal {
     @Override
     public String ToReal(Value v) {
         return (String.format("x%.3f", Math.pow(2.0, (v.getDouble()) / 12.0)));
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<unit1>[xX\\*]?)\\p{Space}*(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit2>[xX\\*]?)");
+        Matcher matcher = pattern.matcher(s);
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not PitchToRatio", 0);
+            }
+
+            String units1 = matcher.group("unit1");
+            String units2 = matcher.group("unit2");
+            if (!(units1.contains("x") || units1.contains("X") || units1.contains("*") || units2.contains("x") || units2.contains("X") || units2.contains("*")))
+                throw new ParseException("Not PitchToRatio", 0);
+
+            return (Math.log(num) / Math.log(2)) * 12.0;
+        }
+
+        throw new ParseException("Not PitchToRatio", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/SquareDB.java
+++ b/src/main/java/axoloti/realunits/SquareDB.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -38,5 +41,25 @@ public class SquareDB implements NativeToReal {
         } else {
             return "-infdB";
         }
+    }
+
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<num>[\\d\\.\\-\\+]*)\\p{Space}*[dD][bB]?");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not SquareDB", 0);
+            }
+
+            return Math.pow(10, (num - maxGain) / 40) * 64.0;
+        }
+
+        throw new ParseException("Not SquareDB", 0);
     }
 }

--- a/src/main/java/axoloti/realunits/SquareRatio.java
+++ b/src/main/java/axoloti/realunits/SquareRatio.java
@@ -18,6 +18,9 @@
 package axoloti.realunits;
 
 import axoloti.datatypes.Value;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.text.ParseException;
 
 /**
  *
@@ -37,4 +40,28 @@ public class SquareRatio implements NativeToReal {
         return (String.format("x%.3f", d * d / 4096.0));
     }
 
+    @Override
+    public double FromReal(String s) throws ParseException {
+        Pattern pattern = Pattern.compile("(?<unit1>[xX\\*]?)\\p{Space}*(?<num>[\\d\\.\\-\\+]*)\\p{Space}*(?<unit2>[xX\\*]?)");
+        Matcher matcher = pattern.matcher(s);
+
+        if (matcher.matches()) {
+            double num;
+
+            try {
+                num = Float.parseFloat(matcher.group("num"));
+            } catch (java.lang.NumberFormatException ex) {
+                throw new ParseException("Not PitchToRatio", 0);
+            }
+
+            String units1 = matcher.group("unit1");
+            String units2 = matcher.group("unit2");
+            if (!(units1.contains("x") || units1.contains("X") || units1.contains("*") || units2.contains("x") || units2.contains("X") || units2.contains("*")))
+                throw new ParseException("Not PitchToRatio", 0);
+
+            return Math.sqrt(num * 4096.0);
+        }
+
+        throw new ParseException("Not PitchToRatio", 0);
+    }
 }

--- a/src/main/java/components/control/DialComponent.java
+++ b/src/main/java/components/control/DialComponent.java
@@ -39,6 +39,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.text.ParseException;
 
 /**
  *
@@ -213,9 +214,24 @@ public class DialComponent extends ACtrlComponent {
                     break;
                 case KeyEvent.VK_ENTER:
                     fireEventAdjustmentBegin();
-                    try {
-                        setValue(Float.parseFloat(keybBuffer));
-                    } catch (java.lang.NumberFormatException ex) {
+                    boolean converted = false;
+                    // parseFloat accepts d & f - try the convs first
+                    if (convs != null) {
+                        for (NativeToReal c : convs) {
+                            try {
+                                setValue(c.FromReal(keybBuffer));
+                                converted = true;
+                                break;
+                            } catch (ParseException ex2) {
+                            }
+                        }
+                    }
+                    if (!converted) {
+                        // otherwise, try parsing
+                        try {
+                            setValue(Float.parseFloat(keybBuffer));
+                        } catch (java.lang.NumberFormatException ex) {
+                        }
                     }
                     fireEventAdjustmentFinished();
                     keybBuffer = "";
@@ -249,6 +265,43 @@ public class DialComponent extends ACtrlComponent {
                 case '9':
                 case '0':
                 case '.':
+                case ' ':
+                case '+':
+                case '*':
+                case '/':
+                case '#':
+                case 'a':
+                case 'A':
+                case 'b':
+                case 'B':
+                case 'c':
+                case 'C':
+                case 'd':
+                case 'D':
+                case 'e':
+                case 'E':
+                case 'f':
+                case 'F':
+                case 'g':
+                case 'G':
+                case 'h':
+                case 'H':
+                case 'i':
+                case 'I':
+                case 'k':
+                case 'K':
+                case 'm':
+                case 'M':
+                case 'n':
+                case 'N':
+                case 'q':
+                case 'Q':
+                case 's':
+                case 'S':
+                case 'x':
+                case 'X':
+                case 'z':
+                case 'Z':
                     keybBuffer += ke.getKeyChar();
                     ke.consume();
                     break;


### PR DESCRIPTION
Hi,

These patches allow modifiers to be used when typing values into dials, e.g. 'x' for ratios, 'h' for frequencies, 's' for periods, 'd' for decibels, '/' for bpms. 'k'ilo and 'm'illi prefixes are supported, and extraneous spaces and letters should be silently eaten. I've tried to make it as "do what I mean" as I could without making it contradictory, ambiguous, or unpredictable.

I'm sure there'll be room for improvement, but I thought I'd get this out there.

Lisa