### PR TITLE
Fix MainFrame close infinite loop

### DIFF
--- a/src/main/java/axoloti/abstractui/DocumentWindowList.java
+++ b/src/main/java/axoloti/abstractui/DocumentWindowList.java
@@ -40,4 +40,13 @@ public class DocumentWindowList {
     static public ArrayList<DocumentWindow> GetList() {
         return list;
     }
+
+    static public boolean AskCloseAll() {
+        for(DocumentWindow dw : (ArrayList<DocumentWindow>) list.clone()) {
+            if (dw.askClose()) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/axoloti/swingui/MainFrame.java
+++ b/src/main/java/axoloti/swingui/MainFrame.java
@@ -822,15 +822,13 @@ public final class MainFrame extends TJFrame implements ActionListener {
     }
 
     public void Quit() {
-        while (!DocumentWindowList.GetList().isEmpty()) {
-            if (DocumentWindowList.GetList().get(0).askClose()) {
-                return;
-            }
+        if(DocumentWindowList.AskCloseAll()) {
+            return;
         }
+        
         Preferences.getPreferences().SavePrefs();
-        if (DocumentWindowList.GetList().isEmpty()) {
-            System.exit(0);
-        }
+        dispose();
+        System.exit(0);
     }
 
     private void setCpuID(String cpuId) {


### PR DESCRIPTION
Previously MainFrame never unregistered itself, so DocumentWindowList was non-empty forever hanging the app on close.