### PR TITLE
Fix single selected object deletion

### DIFF
--- a/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceViewAbstract.java
+++ b/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceViewAbstract.java
@@ -118,7 +118,7 @@ public class AxoObjectInstanceViewAbstract extends ViewPanel<ObjectInstanceContr
     @Override
     public void mouseClicked(MouseEvent me) {
         if (getPatchView() != null) {
-            grabFocus();
+            getPatchView().requestFocus();
             if (me.getClickCount() == 1) {
                 if (me.isShiftDown()) {
                     getModel().setSelected(!getModel().getSelected());
@@ -186,7 +186,7 @@ public class AxoObjectInstanceViewAbstract extends ViewPanel<ObjectInstanceContr
     ArrayList<AxoObjectInstanceViewAbstract> draggingObjects = null;
 
     protected void handleMousePressed(MouseEvent me) {
-        grabFocus();
+        getPatchView().requestFocus();
         if (getPatchView() != null) {
             if (me.isPopupTrigger()) {
                 JPopupMenu p = CreatePopupMenu();


### PR DESCRIPTION
Currently, if you click on one object to select it (rather than drawing a selection bounding box), it grabs focus and then subsequent key operation events like deletion and arrow key movement have no effect because they don't reach the handler attached to Layers. If we keep the focus on Layers, then a selected-by-click object acts exactly like bounding box select objects.