### PR TITLE
Re-enable object editor

### DIFF
--- a/src/main/java/axoloti/object/AxoObject.java
+++ b/src/main/java/axoloti/object/AxoObject.java
@@ -288,40 +288,23 @@ public class AxoObject extends AxoObjectAbstract {
     }
 
     AxoObjectEditor editor;
-
-    Rectangle editorBounds;
-    Integer editorActiveTabIndex;
-
-    public void setEditorBounds(Rectangle editorBounds) {
-        if (editorBounds != null) {
-            editor.setBounds(editorBounds);
-        } else if (this.editorBounds != null) {
-            editor.setBounds(this.editorBounds);
-        }
-
-    }
-
-    public void setEditorActiveTabIndex(Integer editorActiveTabIndex) {
-        if (editorActiveTabIndex != null) {
-            editor.setActiveTabIndex(editorActiveTabIndex);
-        } else if (this.editorActiveTabIndex != null) {
-            editor.setActiveTabIndex(this.editorActiveTabIndex);
-        }
-    }
-
+    AxoObjectEditor.UIState stateOnPreviousClose;
+    
     @Override
-    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex) {
+    public void OpenEditor() {
         if (editor == null) {
             ObjectController ctrl = createController(null, null);
             editor = new AxoObjectEditor(ctrl);
+            editor.restoreTo(stateOnPreviousClose);
         }
-
-        setEditorBounds(editorBounds);
-        setEditorActiveTabIndex(editorActiveTabIndex);
+        editor.setVisible(true);
         editor.toFront();
     }
 
     public void CloseEditor() {
+        if(editor != null) {
+            stateOnPreviousClose = editor.getUIState();
+        }
         editor = null;
     }
 

--- a/src/main/java/axoloti/object/AxoObjectAbstract0.java
+++ b/src/main/java/axoloti/object/AxoObjectAbstract0.java
@@ -104,7 +104,7 @@ public abstract class AxoObjectAbstract0 extends AxoObjectAbstract {
     }
 
     @Override
-    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex) {        
+    public void OpenEditor() {
     }
 
     @Override

--- a/src/main/java/axoloti/object/AxoObjectFromPatch.java
+++ b/src/main/java/axoloti/object/AxoObjectFromPatch.java
@@ -87,7 +87,7 @@ public class AxoObjectFromPatch extends AxoObject {
     }
 
     @Override
-    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex) {
+    public void OpenEditor() {
         if (pf == null) {
             pf = new PatchFrame(patchController, QCmdProcessor.getQCmdProcessor());
         }

--- a/src/main/java/axoloti/object/IAxoObject.java
+++ b/src/main/java/axoloti/object/IAxoObject.java
@@ -79,7 +79,7 @@ public interface IAxoObject extends IModel {
 
     public File GetHelpPatchFile();
 
-    public void OpenEditor(Rectangle editorBounds, Integer editorActiveTabIndex);
+    public void OpenEditor();
 
     public ArrayList<SDFileReference> getFileDepends();
 }

--- a/src/main/java/axoloti/patch/object/AxoObjectInstance.java
+++ b/src/main/java/axoloti/patch/object/AxoObjectInstance.java
@@ -321,9 +321,6 @@ public class AxoObjectInstance extends AxoObjectInstanceAbstract {
         }
     }
 
-    public Rectangle editorBounds;
-    public Integer editorActiveTabIndex;
-
     @Override
     public void dispose() {
     }

--- a/src/main/java/axoloti/piccolo/objectviews/PAxoObjectInstanceView.java
+++ b/src/main/java/axoloti/piccolo/objectviews/PAxoObjectInstanceView.java
@@ -400,7 +400,7 @@ public class PAxoObjectInstanceView extends PAxoObjectInstanceViewAbstract imple
     }
 
     public void OpenEditor() {
-        getType().OpenEditor(model.editorBounds, model.editorActiveTabIndex);
+        getType().OpenEditor();
     }
 
     public ArrayList<AttributeInstanceView> attributeInstanceViews = new ArrayList<AttributeInstanceView>();

--- a/src/main/java/axoloti/swingui/objecteditor/AxoObjectEditor.java
+++ b/src/main/java/axoloti/swingui/objecteditor/AxoObjectEditor.java
@@ -30,6 +30,7 @@ import axoloti.property.Property;
 import axoloti.utils.AxolotiLibrary;
 import axoloti.utils.OSDetect;
 import java.awt.BorderLayout;
+import java.awt.Rectangle;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyChangeEvent;
@@ -461,11 +462,11 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, IVi
         getModel().CloseEditor();
     }
 
-    public int getActiveTabIndex() {
+    private int getActiveTabIndex() {
         return this.jTabbedPane1.getSelectedIndex();
     }
 
-    public void setActiveTabIndex(int n) {
+    private void setActiveTabIndex(int n) {
         this.jTabbedPane1.setSelectedIndex(n);
     }
 
@@ -561,6 +562,7 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, IVi
         );
 
         setDefaultCloseOperation(javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE);
+        setPreferredSize(new java.awt.Dimension(540, 400));
         addWindowFocusListener(new java.awt.event.WindowFocusListener() {
             public void windowGainedFocus(java.awt.event.WindowEvent evt) {
             }
@@ -568,6 +570,11 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, IVi
                 formWindowLostFocus(evt);
             }
         });
+        addWindowListener(new java.awt.event.WindowAdapter() {
+                public void windowClosing(java.awt.event.WindowEvent evt) {
+                    askClose();
+                }
+            });
         getContentPane().setLayout(new javax.swing.BoxLayout(getContentPane(), javax.swing.BoxLayout.PAGE_AXIS));
         getContentPane().add(jLabel4);
 
@@ -960,4 +967,22 @@ public final class AxoObjectEditor extends JFrame implements DocumentWindow, IVi
         super.toFront();
     }
 
+    public class UIState {
+        Rectangle bounds;
+        Integer activeTabIndex;
+    }
+
+    public UIState getUIState() {
+        UIState state = new UIState();
+        state.bounds = getBounds();
+        state.activeTabIndex = getActiveTabIndex();
+        return state;
+    }
+
+    public void restoreTo(UIState state) {
+        if(state != null) {
+            setBounds(state.bounds);
+            setActiveTabIndex(state.activeTabIndex);
+        }
+    }
 }

--- a/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceView.java
+++ b/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceView.java
@@ -421,7 +421,7 @@ public class AxoObjectInstanceView extends AxoObjectInstanceViewAbstract impleme
     }
 
     public void OpenEditor() {
-        getType().OpenEditor(getModel().editorBounds, getModel().editorActiveTabIndex);
+        getType().OpenEditor();
     }
 
     @Override

--- a/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceViewPatcherObject.java
+++ b/src/main/java/axoloti/swingui/patch/object/AxoObjectInstanceViewPatcherObject.java
@@ -10,8 +10,9 @@ import javax.swing.SwingUtilities;
 class AxoObjectInstanceViewPatcherObject extends AxoObjectInstanceView {
 
     ButtonComponent BtnEdit;
-    AxoObjectEditor aoe;
-
+    AxoObjectEditor editor;
+    AxoObjectEditor.UIState stateOnPreviousClose;
+    
     public AxoObjectInstanceViewPatcherObject(ObjectInstanceController controller, PatchViewSwing patchView) {
         super(controller, patchView);
     }
@@ -43,29 +44,31 @@ class AxoObjectInstanceViewPatcherObject extends AxoObjectInstanceView {
     }
 
     public void edit() {
-        if (aoe == null) {
-            aoe = new AxoObjectEditor(getModel().getController());
+        if (editor == null) {
+            editor = new AxoObjectEditor(getModel().getController());
+            editor.restoreTo(stateOnPreviousClose);
         } else {
-            aoe.updateReferenceXML();
+            editor.updateReferenceXML();
         }
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                aoe.setState(java.awt.Frame.NORMAL);
-                aoe.setVisible(true);
+                editor.setVisible(true);
+                editor.toFront();
             }
         });
     }
 
     public boolean isEditorOpen() {
-        return aoe != null && aoe.isVisible();
+        return editor != null && editor.isVisible();
     }
 
     @Override
     public void dispose() {
-        if (aoe != null) {
-            aoe.Close();
-            aoe = null;
+        if (editor != null) {
+            stateOnPreviousClose = editor.getUIState();
+            editor.Close();
+            editor = null;
         }
     }
 


### PR DESCRIPTION
Currently, in experimental, selecting "edit object definition" from the object menu does nothing. The editor frame is created, but remains invisible. This PR re-enables it and simplifies persistence of its bounds and active-tab state. The editor itself will need further verification as we continue development on this branch.