### PR TITLE
Fix tricky textfield recursive edit bug

### DIFF
--- a/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewObjRef.java
+++ b/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewObjRef.java
@@ -11,6 +11,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
@@ -60,7 +61,12 @@ class AttributeInstanceViewObjRef extends AttributeInstanceViewString {
         TFObjName.getDocument().addDocumentListener(new DocumentListener() {
 
             void update() {
-                getController().setModelUndoableProperty(AttributeInstanceObjRef.ATTR_VALUE, TFObjName.getText());
+                SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            getController().setModelUndoableProperty(AttributeInstanceObjRef.ATTR_VALUE, TFObjName.getText());
+                        }
+                    });
             }
 
             @Override

--- a/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewSDFile.java
+++ b/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewSDFile.java
@@ -46,7 +46,12 @@ class AttributeInstanceViewSDFile extends AttributeInstanceViewString {
         add(TFFileName);
         TFFileName.getDocument().addDocumentListener(new DocumentListener() {
             void update() {
-                //getController().changeValue(TFFileName.getText());
+                SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            getController().setModelUndoableProperty(AttributeInstanceSDFile.ATTR_VALUE, TFFileName.getText());
+                        }
+                    });
             }
 
             @Override

--- a/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewTablename.java
+++ b/src/main/java/axoloti/swingui/patch/object/attribute/AttributeInstanceViewTablename.java
@@ -9,6 +9,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import javax.swing.JLabel;
 import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
@@ -43,7 +44,12 @@ class AttributeInstanceViewTablename extends AttributeInstanceViewString {
         TFtableName.getDocument().addDocumentListener(new DocumentListener() {
 
             void update() {
-                getController().setModelUndoableProperty(AttributeInstanceTablename.ATTR_VALUE, TFtableName.getText());
+                SwingUtilities.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            getController().setModelUndoableProperty(AttributeInstanceTablename.ATTR_VALUE, TFtableName.getText());
+                        }
+                    });
             }
 
             @Override


### PR DESCRIPTION
The document associated with a textfield is modified recursively and an exception is thrown if edited when there are multiple views of it open. setModelUndoableProperty triggers a model event that ultimately causes a string to be compared to the current textfield text which has already changed by the time the comparison occurs. Calling setModelUndoableProperty inside an invokeLater defers this comparison and all copies of the textfield track the edit as we expect.