### PR TITLE
Fix 'new view' live state

### DIFF
--- a/src/main/java/axoloti/swingui/patch/PatchFrame.java
+++ b/src/main/java/axoloti/swingui/patch/PatchFrame.java
@@ -343,11 +343,8 @@ public class PatchFrame extends javax.swing.JFrame implements DocumentWindow, Co
 
     @Override
     public void ShowConnect() {
-        if (getPatchController().isLocked()) {
-            getPatchController().setLocked(false);
-        }
-        jCheckBoxLive.setSelected(false);
-        jCheckBoxMenuItemLive.setSelected(false);
+        jCheckBoxLive.setSelected(getPatchController().isLocked());
+        jCheckBoxMenuItemLive.setSelected(getPatchController().isLocked());
         ShowConnect1(true);
     }
 


### PR DESCRIPTION
If a new view is created of a patch view that is already live, we explicitly unlock it, so the patch is still live, but all views of it are unlocked. This change makes the new view respect the lock state of the patch when it is created (ShowConnect is called during PatchFrame creation if the connection is connected). It doesn't seem like there is a case where ShowConnect will be called, and we would want to explicitly unlock a locked patch.