### PR TITLE
Fix initial undo/dirty state

### DIFF
--- a/src/main/java/axoloti/abstractui/PatchView.java
+++ b/src/main/java/axoloti/abstractui/PatchView.java
@@ -350,6 +350,7 @@ public abstract class PatchView extends PatchAbstractView {
         long ChronoStart = Calendar.getInstance().getTimeInMillis();
         AbstractDocumentRoot documentRoot = new AbstractDocumentRoot();
         PatchController patchController = new PatchController(pm, documentRoot, null);
+        documentRoot.getUndoManager().discardAllEdits();
         long ChronoControllerCreated = Calendar.getInstance().getTimeInMillis();
         System.out.println("ChronoControllerCreated " + (ChronoControllerCreated - ChronoStart));
         PatchFrame pf = new PatchFrame(patchController, QCmdProcessor.getQCmdProcessor());


### PR DESCRIPTION
There are a couple of undo bugs in 'experimental' right now:
1. A patch is considered dirty immediately after launch, so the user is prompted to save on close even if no edits have occurred.
2. By repeatedly undoing after making some edits, it is possible to go beyond the initial state the patch had when it was opened. Visually this looks like everything is removed from the patch view.

This is happening because UndoableEdits accumulate in the UndoManager when a patch is opened; setModelUndoableProperty is called repeatedly during the initialization process. One simple way to fix this is to discard these edits just before a PatchFrame is created. The dirty state works as we expect with this change: 1. A patch is clean immediately after being opened. 2. Undoing all the edits back to the initial state of the patch results in a clean patch and it's not possible to go beyond that initial state.