### PR TITLE
Fix linux build.sh typo

### DIFF
--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -22,7 +22,7 @@ elif [ -f /etc/debian_version ]; then
     if [ -n "`grep 8.6 /etc/debian_version`" ] && [ -z "`uname -m | grep x86_64`" ]; then
       OS=DebianJessie32bit
     fi
-    
+
 elif [ -f /etc/arch-release ]; then
     OS=Archlinux
 elif [ -f /etc/gentoo-release ]; then
@@ -87,7 +87,7 @@ mkdir -p "${PLATFORM_ROOT}/src"
 
 
 CH_VERSION=18.2.0
-if [ ! -d "${PLATFORM_ROOT}/../ChibiOS_${CH_VERSION}" ]; 
+if [ ! -d "${PLATFORM_ROOT}/../ChibiOS_${CH_VERSION}" ];
 then
     cd "${PLATFORM_ROOT}/src"
     ARDIR=ChibiOS_${CH_VERSION}
@@ -101,7 +101,7 @@ then
     fi
     unzip -q -o ${ARCHIVE}
     cd ${ARDIR}/ext
-    7z x ./fatfs-0.13-patched.7z
+    7z x ./fatfs-0.13_patched.7z
     cd ../../
     mv ${ARDIR} ../..
 
@@ -124,7 +124,7 @@ then
     cd "${PLATFORM_ROOT}"
     ARDIR=gcc-arm-none-eabi-6-2017-q1-update
     ARCHIVE=${ARDIR}-linux.tar.bz2
-    if [ ! -f ${ARCHIVE} ]; 
+    if [ ! -f ${ARCHIVE} ];
     then
         echo "downloading ${ARCHIVE}"
         curl -L https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/6_1-2017q1/${ARCHIVE} > ${ARCHIVE}


### PR DESCRIPTION
The key change is at line 104. There was a dash instead of an underscore in the archive path causing the build to fail. "./fatfs-0.13-patched.7z" should be "fatfs-0.13_patched.7z." The rest is just automated trailing whitespace removal.