### PR TITLE
Update launch script jvmargs for latest Marlin

### DIFF
--- a/Axoloti.bat
+++ b/Axoloti.bat
@@ -45,7 +45,7 @@ if not defined JAVAHOME (
 
 echo JavaHome: %JAVAHOME%
 set PATH=%JAVAHOME%\bin
-set MARLIN_JVMARGS="-Xbootclasspath/a:lib/marlin-0.8.2.jar -Xbootclasspath/a:lib/marlin-0.8.2-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"
+set MARLIN_JVMARGS="-Xbootclasspath/a:lib/marlin-0.9.1-Unsafe.jar -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"
 java %MARLIN_JVMARGS% -jar dist/axoloti.jar %*
 
 :end

--- a/Axoloti.sh
+++ b/Axoloti.sh
@@ -24,7 +24,7 @@ export axoloti_home=${axoloti_home:="$rootdir"}
 
 which java >/dev/null || echo "java not found in path"
 
-marlin_jvmargs='-Xbootclasspath/a:lib/marlin-0.8.2.jar -Xbootclasspath/a:lib/marlin-0.8.2-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine'
+marlin_jvmargs='-Xbootclasspath/a:lib/marlin-0.9.1-Unsafe.jar -Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine'
 
 if [ -f $rootdir/dist/Axoloti.jar ]
 then


### PR DESCRIPTION
The launch scripts were still pointing to 0.8.2, so launching the patcher via Axoloti.sh was silently not loading Marlin. We still had the problematic sun-java2d jar there as well.