### PR TITLE
Fix Piccolo initialization refactor glitch

### DIFF
--- a/src/main/java/axoloti/piccolo/patch/object/PAxoObjectInstanceViewAbstract.java
+++ b/src/main/java/axoloti/piccolo/patch/object/PAxoObjectInstanceViewAbstract.java
@@ -80,11 +80,8 @@ public class PAxoObjectInstanceViewAbstract extends PatchPNode implements IAxoOb
         super(patchView);
         this.controller = controller;
         titleBar = new PatchPNode(patchView);
-        initComponent();
-    }
-
-    private void initComponent() {
         setVisible(false);
+        initComponents();
     }
 
     @Override


### PR DESCRIPTION
The refactor to initComponents introduced a bug in Piccolo's object view initialization where we were failing to call needed initialization code.

There's still a subtle issue with Inlet and Outlet labels and icons that only affects Piccolo. Working on a fix.