### PR TITLE
Fix linux build on experimental branch

### DIFF
--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -52,6 +52,8 @@ case $OS in
         set +e
         if ! install_lib_bz2; then
             set -e
+            sudo dpkg --add-architecture i386
+            sudo apt-get update
             sudo apt-get install -y libbz2-1.0:i386
         fi
         ;;

--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -37,8 +37,8 @@ case $OS in
     Ubuntu|Debian|DebianJessie32bit)
         echo "apt-get install -y libtool libudev-dev automake autoconf ant curl lib32z1 lib32ncurses5 lib32bz2-1.0 p7zip-full"
       if [ $OS==DebianJessie32bit ]; then
-            sudo apt-get install -y libtool libudev-dev automake autoconf \
-               ant curl p7zip-full fakeroot
+            sudo apt-get install -y build-essential libtool libudev-dev automake autoconf \
+               ant curl p7zip-full fakeroot unzip udev
       else
             sudo apt-get install -y libtool libudev-dev automake autoconf \
                ant curl lib32z1 lib32ncurses5 p7zip-full fakeroot

--- a/platform_linux/build.sh
+++ b/platform_linux/build.sh
@@ -188,16 +188,16 @@ fi
 
 case $OS in
     Ubuntu|Debian)
-        echo "apt-get install openjdk-7-jdk"
-        sudo apt-get install openjdk-7-jdk
+        echo "apt-get install openjdk-8-jdk"
+        sudo apt-get install openjdk-8-jdk
         ;;
     Archlinux)
-        echo "pacman -Syy jdk7-openjdk"
-        sudo pacman -S --noconfirm jdk7-openjdk
+        echo "pacman -Syy jdk8-openjdk"
+        sudo pacman -S --noconfirm jdk8-openjdk
         ;;
     Gentoo)
-	echo "emerge --update jdk:1.7 ant"
-	sudo emerge --update jdk:1.7 ant
+	echo "emerge --update jdk:1.8 ant"
+	sudo emerge --update jdk:1.8 ant
 	;;
 esac
 


### PR DESCRIPTION
Couple of small changes/fixed to make the `platform_linux/build.sh` script work again, tested using a `ubuntu:18.04` container.

Tbh I don't think this script should install udev rules, but since I didn't want to introduce any unrelated changes for a simple fix I added `udev` to the list of packages to install otherwise the `/etc/udev/rules.d` directory doesn't exist and `udevadm` is missing.

Fixes #433 