### PR TITLE
Fix travis builds / ensure oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
-os:
-  - linux
-  - osx
 language: java
-osx_image: xcode8.2
+jdk:
+  - oraclejdk8
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+    - os: osx
+      osx_image: xcode8.3
 before_install:
   - >
     case "${TRAVIS_OS_NAME:-linux}" in
     linux)
       sudo apt-get update -qq
-      sudo apt-get install -qq oracle-java8-installer fakeroot
-      jdk_switcher use oraclejdk8
+      sudo apt-get install -qq fakeroot
       ./platform_linux/build.sh
       ;;
     osx)


### PR DESCRIPTION
Closes #443 

Travis was using openjdk 11 for linux and java 10 for osx, ignoring whatever was custom installed by the script. The [docs](https://docs.travis-ci.com/user/languages/java/#testing-against-multiple-jdks) suggest using the `jdk` keyword, but:
- oraclejdk8 is no longer preinstalled in the default linux distribution (xenial). https://github.com/travis-ci/travis-ci/issues/10290 recommends using "trusty" or moving to openjdk.
- Something similar was happening on osx for xcode8.2 (which is not even shown in the [docs](https://docs.travis-ci.com/user/reference/osx/#jdk-and-macos)).